### PR TITLE
Establish project foundation: packaging, CI, linting, tests, docs

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -1,0 +1,63 @@
+# Automation protocol
+
+This repository is developed by two collaborating maintainers who coordinate **entirely
+through GitHub** — pull requests, reviews, comments, and issues. This document is the
+contract they both follow. The quality bar lives in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Roles
+
+- **Developer** — implements roadmap items and issues, opens PRs against `main`, responds
+  to review feedback, and files issues for bugs and gaps discovered while working.
+- **Reviewer** — reviews open PRs, approves and merges sound work, requests changes
+  otherwise, and also picks up open issues to implement.
+
+Both roles develop and both roles review. Neither merges their own pull request, so every
+change is seen by the other maintainer before it lands.
+
+## Branches and commits
+
+- Never commit directly to `main`. All changes flow through PRs.
+- Branch names: `feat/<slug>`, `fix/<slug>`, `refactor/<slug>`, `chore/<slug>`,
+  `docs/<slug>`, `test/<slug>`.
+- Commits follow Conventional Commits (see `CONTRIBUTING.md`).
+
+## Pull requests
+
+- One logical change per PR. Keep diffs small and focused.
+- The description states motivation and links the issue it closes (`Closes #123`).
+- A PR is ready to merge when: CI is green, the change meets the style bar, and all review
+  threads are resolved.
+- Merge with squash and delete the branch. Only merge PRs authored by the *other*
+  maintainer.
+
+## Reviews
+
+- Leave specific, actionable comments. Block only on real defects, failing tests/CI, or
+  clear style violations — not preferences or nitpicks.
+- Converge: after about three rounds on one PR, stop blocking. Either approve with a
+  follow-up note or open a tracking issue, then merge.
+
+## Issues
+
+Issues are the shared backlog. Labels:
+
+- Type: `type:feat`, `type:bug`, `type:chore`, `type:docs`
+- Priority: `priority:high`, `priority:medium`, `priority:low`
+- Status: `status:ready` (actionable now), `status:blocked` (waiting on something)
+
+Workflow:
+
+- Only work issues labeled `status:ready`.
+- Self-assign an issue before starting so the other maintainer doesn't duplicate it.
+- File new issues with a clear scope and acceptance criteria.
+
+## Definition of done
+
+The project is "done" when the roadmap milestone is complete, there are no open
+`status:ready` issues, no open PRs, and CI is green on `main`. When that state holds, there
+is nothing to do.
+
+## Kill switch
+
+If a file named `STOP` exists at the repository root on `main`, both maintainers halt
+immediately and take no action until it is removed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Lint
+        run: ruff check src tests
+      - name: Format check
+        run: ruff format --check src tests
+      - name: Test
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Byte-compiled / packaging
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+
+# Virtual environments
+.venv/
+venv/
+.env
+
+# Tooling caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# OS / editor
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for contributing. This guide keeps the codebase consistent and reviewable.
+
+## Development setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+The package uses a `src/` layout; the importable package is `recommender_systems`.
+
+## Code style
+
+- Formatting and linting are handled by [Ruff](https://docs.astral.sh/ruff/). Run
+  `ruff format` and `ruff check` before committing; CI enforces both.
+- Line length is 100 characters. Target Python 3.10+.
+- Type-hint all public functions and methods.
+- Public functions and classes get NumPy-style docstrings (Parameters / Returns).
+  Don't document the obvious — comment *why*, not *what*.
+- Prefer small, pure functions and explicit arguments over hidden state. No code should
+  run at import time.
+
+## Tests
+
+- Every algorithm and bug fix ships with tests under `tests/`.
+- Use small, in-memory fixtures (a handful of users/items) so tests stay fast and
+  deterministic.
+- Run the suite with `pytest`.
+
+## Commits and pull requests
+
+- Write [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`,
+  `refactor:`, `test:`, `docs:`, `chore:`. Imperative mood, no trailing period.
+- Keep each PR to one logical change. Smaller PRs review faster and merge sooner.
+- Branch names: `feat/<slug>`, `fix/<slug>`, `refactor/<slug>`, `chore/<slug>`.
+- PR descriptions state the motivation and link the issue they close.
+- A PR is mergeable when CI is green, the diff is focused, and review threads are resolved.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+Turn this collection of scripts into a polished, modern, well-tested recommender systems
+library worth showcasing.
+
+## Phase 0 — Foundation (in progress)
+
+Packaging (`pyproject.toml`, `src/` layout), Ruff lint/format, pytest, CI, and contributor
+docs. No behavior change yet.
+
+## Phase 1 — Migrate the legacy modules
+
+Move each existing script into `recommender_systems/`, with a clean signature, type hints,
+docstrings, input validation, and tests. Remove import-time side effects. One module per PR.
+
+## Phase 2 — A unified API
+
+Introduce a common interface (e.g. a `Recommender` base with `fit` / `recommend`) so every
+algorithm is interchangeable, plus shared utilities for building user–item matrices and
+train/test splits.
+
+## Phase 3 — More algorithms and evaluation
+
+- Baselines: most-popular, mean-rating.
+- Neighborhood: user/item kNN collaborative filtering.
+- Matrix factorization: SVD, ALS, and an implicit-feedback model (BPR).
+- Content-based: a unified TF-IDF / embeddings recommender.
+- Hybrid: combine collaborative and content signals.
+- Evaluation: precision@k, recall@k, MAP, NDCG, coverage, and a `MovieLens` loader.
+
+## Phase 4 — Documentation and examples
+
+Worked examples, benchmarks across algorithms, and a published docs site.
+
+## Known issues (carried over from the original code)
+
+- A source file is named with a leading space (`" item_based_dot_product.py"`).
+- `model_based_collaborative_filter.py` executes at import time instead of inside a guard.
+- `get_recommended_items` has an inconsistent signature across modules.
+- The README has duplicated and mismatched algorithm descriptions.
+- No input validation and no tests on any existing module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "recommender-systems"
+description = "A collection of classic and modern recommender system algorithms."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "David Burton" }]
+keywords = [
+    "recommender-systems",
+    "collaborative-filtering",
+    "content-based",
+    "machine-learning",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "numpy>=1.23",
+    "pandas>=1.5",
+    "scikit-learn>=1.2",
+    "scipy>=1.9",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+embeddings = ["gensim>=4.3"]
+dev = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+    "ruff>=0.4",
+]
+
+[project.urls]
+Homepage = "https://github.com/Burton-David/Recommender-Systems"
+Repository = "https://github.com/Burton-David/Recommender-Systems"
+
+[tool.hatch.version]
+path = "src/recommender_systems/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/recommender_systems"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "C4", "N", "RUF"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra --strict-markers"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -1,0 +1,3 @@
+"""Recommender Systems: classic and modern recommendation algorithms."""
+
+__version__ = "0.1.0"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,6 @@
+import recommender_systems
+
+
+def test_version_is_exposed():
+    assert isinstance(recommender_systems.__version__, str)
+    assert recommender_systems.__version__


### PR DESCRIPTION
Phase 0 of the modernization (see `ROADMAP.md`). Sets up the engineering foundation without changing any existing behavior.

- `pyproject.toml` — `src/` layout packaging via hatchling; core deps (numpy, pandas, scikit-learn, scipy) with an optional `embeddings` extra for gensim and a `dev` extra
- Ruff lint + format config and pytest config
- `recommender_systems` package skeleton plus a smoke test
- GitHub Actions CI across Python 3.10–3.12 (ruff check, format check, pytest)
- `CONTRIBUTING.md` (style/quality bar), `.github/AUTOMATION.md` (maintainer coordination protocol), and `ROADMAP.md`

The legacy top-level scripts are intentionally left untouched; Phase 1 migrates them into the package one at a time.

After this merges I'll register the CI checks as required status checks on `main`.