### PR TITLE
Add common Recommender interface

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -1,3 +1,7 @@
 """Recommender Systems: classic and modern recommendation algorithms."""
 
+from recommender_systems.base import Recommender
+
 __version__ = "0.1.0"
+
+__all__ = ["Recommender"]

--- a/src/recommender_systems/base.py
+++ b/src/recommender_systems/base.py
@@ -1,0 +1,53 @@
+"""The common interface shared by all recommenders."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Hashable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = ["Recommender"]
+
+
+class Recommender(ABC):
+    """Abstract base class for recommendation algorithms.
+
+    Concrete recommenders learn from interaction data in :meth:`fit` and produce a ranked
+    list of item ids in :meth:`recommend`. Sharing one interface lets algorithms be swapped
+    and evaluated interchangeably.
+    """
+
+    @abstractmethod
+    def fit(self, ratings: pd.DataFrame) -> Recommender:
+        """Train on a ratings frame.
+
+        Parameters
+        ----------
+        ratings:
+            Interaction data with at least ``user_id``, ``item_id`` and ``rating`` columns.
+
+        Returns
+        -------
+        Recommender
+            The fitted instance, so calls can be chained.
+        """
+
+    @abstractmethod
+    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
+        """Return the top-``n`` recommended item ids for ``user_id``.
+
+        Parameters
+        ----------
+        user_id:
+            The user to recommend for.
+        n:
+            Maximum number of items to return.
+
+        Returns
+        -------
+        list of Hashable
+            Item ids ordered from most to least recommended.
+        """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+
+from recommender_systems import Recommender
+
+
+def test_cannot_instantiate_abstract_base():
+    with pytest.raises(TypeError):
+        Recommender()
+
+
+class _MostPopular(Recommender):
+    """Minimal reference implementation used to exercise the interface."""
+
+    def fit(self, ratings):
+        self._ranking = (
+            ratings.groupby("item_id").size().sort_values(ascending=False).index.tolist()
+        )
+        return self
+
+    def recommend(self, user_id, n=10):
+        return self._ranking[:n]
+
+
+def test_reference_implementation_obeys_contract():
+    ratings = pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 2, 3],
+            "item_id": ["a", "b", "a", "c", "a"],
+            "rating": [5, 4, 3, 5, 4],
+        }
+    )
+
+    model = _MostPopular().fit(ratings)
+
+    assert model.recommend(user_id=1, n=2) == ["a", "b"]
+    assert model.recommend(user_id=1, n=10)[0] == "a"


### PR DESCRIPTION
Implements the keystone interface from the roadmap.

- `recommender_systems.base.Recommender` — an ABC with `fit(ratings)` and `recommend(user_id, n)`, a documented contract, exported from the package root.
- Tests cover the abstract-instantiation guard and a small reference implementation.

Once this merges, the migration and new-algorithm issues currently `status:blocked` can move to `status:ready`.

Closes #6