### PR TITLE
Add MovieLens 100k dataset loader

### DIFF
--- a/src/recommender_systems/datasets.py
+++ b/src/recommender_systems/datasets.py
@@ -1,0 +1,43 @@
+"""Dataset loaders for common recommender benchmarks."""
+
+from __future__ import annotations
+
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+__all__ = ["load_movielens_100k"]
+
+_ML_100K_URL = "https://files.grouplens.org/datasets/movielens/ml-100k.zip"
+_DEFAULT_HOME = Path.home() / ".recommender_systems"
+_COLUMNS = ["user_id", "item_id", "rating", "timestamp"]
+
+
+def load_movielens_100k(data_home: str | Path | None = None) -> pd.DataFrame:
+    """Load the MovieLens 100k ratings, downloading and caching on first use.
+
+    Parameters
+    ----------
+    data_home
+        Directory to cache the dataset in. Defaults to ``~/.recommender_systems``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Ratings with columns ``user_id``, ``item_id``, ``rating``, ``timestamp``.
+    """
+    home = Path(data_home) if data_home is not None else _DEFAULT_HOME
+    data_file = home / "ml-100k" / "u.data"
+    if not data_file.exists():
+        _download_and_extract(home)
+    return pd.read_csv(data_file, sep="\t", names=_COLUMNS)
+
+
+def _download_and_extract(home: Path) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    archive = home / "ml-100k.zip"
+    urllib.request.urlretrieve(_ML_100K_URL, archive)
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(home)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,15 @@
+from recommender_systems.datasets import load_movielens_100k
+
+
+def test_loads_cached_ratings_without_download(tmp_path):
+    extracted = tmp_path / "ml-100k"
+    extracted.mkdir(parents=True)
+    (extracted / "u.data").write_text(
+        "1\t10\t5\t881250949\n1\t20\t3\t881250949\n2\t10\t4\t881250949\n"
+    )
+
+    ratings = load_movielens_100k(data_home=tmp_path)
+
+    assert list(ratings.columns) == ["user_id", "item_id", "rating", "timestamp"]
+    assert len(ratings) == 3
+    assert ratings.loc[0, "rating"] == 5


### PR DESCRIPTION
A loader for the standard MovieLens 100k benchmark, which the benchmark suite and examples will use.

- `load_movielens_100k(data_home=None)` — downloads and caches on first use, returns a tidy ratings frame (`user_id`, `item_id`, `rating`, `timestamp`).
- The test seeds a cached fixture and exercises the real loader **offline**, so CI needs no network.
- Deliberately does not modify `__init__.py`, to avoid a conflict with the pending PR #26.

Closes #8