### PR TITLE
Add most-popular and mean-rating baselines

### DIFF
--- a/src/recommender_systems/baselines.py
+++ b/src/recommender_systems/baselines.py
@@ -1,0 +1,55 @@
+"""Non-personalized baseline recommenders."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+import pandas as pd
+
+from recommender_systems.base import Recommender
+
+__all__ = ["MeanRating", "MostPopular"]
+
+
+class _RankingBaseline(Recommender):
+    """Recommend items by a global score, skipping ones the user has already rated."""
+
+    def __init__(self) -> None:
+        self._ranking: list[Hashable] = []
+        self._seen: dict[Hashable, set[Hashable]] = {}
+
+    def _rank(self, ratings: pd.DataFrame, scores: pd.Series) -> None:
+        self._ranking = scores.sort_values(ascending=False).index.tolist()
+        self._seen = ratings.groupby("user_id")["item_id"].agg(set).to_dict()
+
+    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
+        seen = self._seen.get(user_id, set())
+        return [item for item in self._ranking if item not in seen][:n]
+
+
+class MostPopular(_RankingBaseline):
+    """Rank items by how often they have been rated."""
+
+    def fit(self, ratings: pd.DataFrame) -> MostPopular:
+        self._rank(ratings, ratings.groupby("item_id").size())
+        return self
+
+
+class MeanRating(_RankingBaseline):
+    """Rank items by mean rating, requiring a minimum number of ratings.
+
+    Parameters
+    ----------
+    min_ratings
+        Minimum number of ratings an item needs to be eligible.
+    """
+
+    def __init__(self, min_ratings: int = 1) -> None:
+        super().__init__()
+        self.min_ratings = min_ratings
+
+    def fit(self, ratings: pd.DataFrame) -> MeanRating:
+        grouped = ratings.groupby("item_id")["rating"]
+        means, counts = grouped.mean(), grouped.size()
+        self._rank(ratings, means[counts >= self.min_ratings])
+        return self

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+from recommender_systems.base import Recommender
+from recommender_systems.baselines import MeanRating, MostPopular
+
+
+def sample_ratings():
+    return pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 2, 3, 3, 3],
+            "item_id": ["a", "b", "a", "c", "a", "b", "c"],
+            "rating": [5, 3, 4, 2, 5, 1, 4],
+        }
+    )
+
+
+def test_baselines_implement_interface():
+    assert issubclass(MostPopular, Recommender)
+    assert issubclass(MeanRating, Recommender)
+
+
+def test_most_popular_ranks_by_count_and_excludes_seen():
+    model = MostPopular().fit(sample_ratings())
+    # counts: a=3, b=2, c=2 -> ranking [a, b, c]; user 1 has seen {a, b}
+    assert model.recommend(1, n=10) == ["c"]
+    assert model.recommend(999, n=2) == ["a", "b"]
+
+
+def test_mean_rating_ranks_by_mean_and_excludes_seen():
+    model = MeanRating().fit(sample_ratings())
+    # means: a=14/3, c=3.0, b=2.0 -> ranking [a, c, b]; user 2 has seen {a, c}
+    assert model.recommend(2, n=10) == ["b"]
+    assert model.recommend(999, n=2) == ["a", "c"]
+
+
+def test_mean_rating_min_ratings_filters_items():
+    model = MeanRating(min_ratings=3).fit(sample_ratings())
+    # only item "a" has at least 3 ratings
+    assert model.recommend(999, n=10) == ["a"]


### PR DESCRIPTION
The first concrete recommenders on the `Recommender` interface, and reference points for the benchmark.

- `MostPopular` — ranks items by rating frequency.
- `MeanRating` — ranks items by mean rating, with a `min_ratings` eligibility threshold.
- Both share a small private base that excludes items the user has already rated; tested.

Establishes the implementation pattern the migrations will follow. Not exported from `__init__.py` yet (deferred to a consolidation pass to avoid parallel-PR conflicts).

Closes #13