### PR TITLE
feat: add beyond-accuracy metrics (diversity, novelty, coverage, serendipity)

### DIFF
--- a/src/recommender_systems/metrics.py
+++ b/src/recommender_systems/metrics.py
@@ -1,20 +1,33 @@
-"""Ranking metrics for top-N recommendation evaluation.
+"""Metrics for top-N recommendation evaluation.
 
-All metrics take parallel sequences of predicted ranked lists and held-out
-relevant item sets — one entry per user — and return a macro-averaged score
-across users that have at least one held-out item. Users with no relevant
-items are skipped from the mean so they don't drag every metric to zero.
+Accuracy metrics (precision, recall, MAP, NDCG) take parallel sequences of
+predicted ranked lists and held-out relevant item sets — one entry per user —
+and return a macro-averaged score across users that have at least one held-out
+item. Beyond-accuracy metrics (diversity, novelty, coverage, serendipity)
+capture different aspects of recommendation quality and are documented inline.
+Users with no relevant items are skipped from each mean so they don't drag the
+score toward zero.
 """
 
-from collections.abc import Collection, Hashable, Sequence
+from collections.abc import Callable, Collection, Hashable, Mapping, Sequence
+from itertools import combinations
 from math import log2
 
 __all__ = [
+    "catalog_coverage",
+    "intra_list_diversity",
     "mean_average_precision",
     "ndcg_at_k",
+    "novelty",
     "precision_at_k",
     "recall_at_k",
+    "serendipity_at_k",
 ]
+
+
+def _validate_k(k: int) -> None:
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
 
 
 def _validate(
@@ -22,8 +35,7 @@ def _validate(
     actual: Sequence[Collection[Hashable]],
     k: int,
 ) -> None:
-    if k <= 0:
-        raise ValueError(f"k must be positive, got {k}")
+    _validate_k(k)
     if len(predicted) != len(actual):
         raise ValueError(
             f"predicted and actual must have the same length, "
@@ -154,4 +166,141 @@ def ndcg_at_k(
         ideal_hits = min(len(truth_set), k)
         idcg = sum(1.0 / log2(i + 1) for i in range(1, ideal_hits + 1))
         scores.append(dcg / idcg if idcg > 0 else 0.0)
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def intra_list_diversity(
+    predicted: Sequence[Sequence[Hashable]],
+    similarity: Callable[[Hashable, Hashable], float],
+    k: int,
+) -> float:
+    """Macro-averaged intra-list dissimilarity across users.
+
+    For each user, dissimilarity averages ``1 - similarity(a, b)`` over all
+    distinct pairs in the top-k recommendations. Users with fewer than two
+    recommendations are skipped — diversity is undefined for singletons.
+
+    Parameters
+    ----------
+    predicted
+        Per-user ranked predictions.
+    similarity
+        Symmetric similarity in ``[0, 1]``. Only off-diagonal pairs are evaluated.
+    k
+        Cutoff for the top of each prediction list.
+    """
+    _validate_k(k)
+    scores: list[float] = []
+    for preds in predicted:
+        top_k = list(preds)[:k]
+        if len(top_k) < 2:
+            continue
+        pairs = list(combinations(top_k, 2))
+        scores.append(sum(1.0 - similarity(a, b) for a, b in pairs) / len(pairs))
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def novelty(
+    predicted: Sequence[Sequence[Hashable]],
+    item_popularity: Mapping[Hashable, float],
+    k: int,
+) -> float:
+    """Mean self-information of recommended items, averaged across users.
+
+    Self-information of item ``i`` is ``-log2(p_i)``; popular items contribute
+    little novelty, rare ones contribute more. Items absent from
+    ``item_popularity`` are skipped within a user's list; users whose entire
+    top-k is unknown are skipped from the mean.
+
+    Parameters
+    ----------
+    predicted
+        Per-user ranked predictions.
+    item_popularity
+        Mapping from item id to its popularity in ``(0, 1]`` (e.g., the
+        fraction of users that have interacted with it).
+    k
+        Cutoff for the top of each prediction list.
+    """
+    _validate_k(k)
+    scores: list[float] = []
+    for preds in predicted:
+        contribs = [
+            -log2(item_popularity[item]) for item in list(preds)[:k] if item in item_popularity
+        ]
+        if not contribs:
+            continue
+        scores.append(sum(contribs) / len(contribs))
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def catalog_coverage(
+    predicted: Sequence[Sequence[Hashable]],
+    catalog: Collection[Hashable],
+    k: int,
+) -> float:
+    """Fraction of the catalog that appears in at least one user's top-k.
+
+    Items recommended outside ``catalog`` are ignored; recommending the same
+    item to many users still only counts it once.
+
+    Parameters
+    ----------
+    predicted
+        Per-user ranked predictions.
+    catalog
+        Items the recommender could have recommended.
+    k
+        Cutoff applied to each user's prediction list.
+    """
+    _validate_k(k)
+    if not catalog:
+        return 0.0
+    catalog_set = set(catalog)
+    recommended: set[Hashable] = set()
+    for preds in predicted:
+        recommended.update(item for item in list(preds)[:k] if item in catalog_set)
+    return len(recommended) / len(catalog_set)
+
+
+def serendipity_at_k(
+    predicted: Sequence[Sequence[Hashable]],
+    actual: Sequence[Collection[Hashable]],
+    expected: Sequence[Collection[Hashable]],
+    k: int,
+) -> float:
+    """Macro-averaged share of top-k that are both relevant and unexpected.
+
+    A recommendation counts as serendipitous when the user finds it relevant
+    (``item in actual``) and a baseline recommender would *not* have surfaced
+    it (``item not in expected``). The ``expected`` list per user is typically
+    drawn from a popularity or otherwise trivial recommender. Users with no
+    relevant items are skipped from the mean.
+
+    Parameters
+    ----------
+    predicted
+        Per-user ranked predictions.
+    actual
+        Per-user relevant items.
+    expected
+        Per-user baseline recommendations; items already inside this set are
+        not serendipitous even if relevant.
+    k
+        Cutoff applied to each user's prediction list.
+    """
+    _validate_k(k)
+    if not (len(predicted) == len(actual) == len(expected)):
+        raise ValueError(
+            f"predicted, actual, and expected must all have the same length, "
+            f"got {len(predicted)}, {len(actual)}, {len(expected)}"
+        )
+    scores: list[float] = []
+    for preds, truth, baseline in zip(predicted, actual, expected, strict=True):
+        if not truth:
+            continue
+        truth_set = set(truth)
+        baseline_set = set(baseline)
+        hits = sum(1 for item in list(preds)[:k] if item in truth_set and item not in baseline_set)
+        scores.append(hits / k)
     return sum(scores) / len(scores) if scores else 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,10 +3,14 @@ import math
 import pytest
 
 from recommender_systems.metrics import (
+    catalog_coverage,
+    intra_list_diversity,
     mean_average_precision,
     ndcg_at_k,
+    novelty,
     precision_at_k,
     recall_at_k,
+    serendipity_at_k,
 )
 
 ALL_METRICS = [precision_at_k, recall_at_k, mean_average_precision, ndcg_at_k]
@@ -110,3 +114,134 @@ def test_invalid_k_raises(metric):
 def test_mismatched_lengths_raise(metric):
     with pytest.raises(ValueError, match="same length"):
         metric([["A"], ["B"]], [{"A"}], k=1)
+
+
+# ---- beyond-accuracy metrics ----
+
+
+def _toy_similarity(a, b):
+    # sim("a","b")=0.5, sim("a","c")=0.0, sim("b","c")=0.5; identical pairs → 1.0
+    table = {
+        ("a", "b"): 0.5,
+        ("a", "c"): 0.0,
+        ("b", "c"): 0.5,
+    }
+    if a == b:
+        return 1.0
+    return table.get((a, b), table.get((b, a), 0.0))
+
+
+def test_intra_list_diversity_worked_example():
+    # top-3 = [a, b, c]; pair distances: (a,b)=0.5, (a,c)=1.0, (b,c)=0.5
+    # mean dissimilarity = (0.5 + 1.0 + 0.5) / 3 = 2/3
+    predicted = [["a", "b", "c"]]
+    assert intra_list_diversity(predicted, _toy_similarity, k=3) == pytest.approx(2 / 3)
+
+
+def test_intra_list_diversity_skips_singleton_lists():
+    # only user 2 contributes (user 1's top-1 has no pairs to compare)
+    predicted = [["a"], ["a", "b"]]
+    # user 2: one pair (a,b), distance = 0.5
+    assert intra_list_diversity(predicted, _toy_similarity, k=2) == pytest.approx(0.5)
+
+
+def test_intra_list_diversity_identical_items_have_zero_diversity():
+    predicted = [["a", "a"]]
+    assert intra_list_diversity(predicted, _toy_similarity, k=2) == pytest.approx(0.0)
+
+
+def test_novelty_worked_example():
+    # popularity: a=1/2, b=1/4, c=1/8 → -log2: 1, 2, 3
+    popularity = {"a": 0.5, "b": 0.25, "c": 0.125}
+    predicted = [["a", "b", "c"]]
+    assert novelty(predicted, popularity, k=3) == pytest.approx((1 + 2 + 3) / 3)
+
+
+def test_novelty_skips_unknown_items():
+    popularity = {"a": 0.5}
+    predicted = [["a", "unknown"]]
+    # only "a" contributes → mean over 1 item = -log2(0.5) = 1
+    assert novelty(predicted, popularity, k=2) == pytest.approx(1.0)
+
+
+def test_novelty_skips_users_whose_topk_is_all_unknown():
+    popularity = {"a": 0.5}
+    predicted = [["a"], ["x", "y"]]
+    # only user 1 contributes
+    assert novelty(predicted, popularity, k=2) == pytest.approx(1.0)
+
+
+def test_catalog_coverage_worked_example():
+    catalog = {"a", "b", "c", "d"}
+    predicted = [["a", "b"], ["a", "c"]]
+    # union recommended = {a, b, c}, catalog = 4 → 3/4
+    assert catalog_coverage(predicted, catalog, k=2) == pytest.approx(0.75)
+
+
+def test_catalog_coverage_respects_k_cutoff():
+    catalog = {"a", "b", "c"}
+    predicted = [["a", "b", "c"]]
+    # k=1 → only "a" counts → 1/3
+    assert catalog_coverage(predicted, catalog, k=1) == pytest.approx(1 / 3)
+
+
+def test_catalog_coverage_empty_catalog_returns_zero():
+    assert catalog_coverage([["a", "b"]], set(), k=5) == 0.0
+
+
+def test_catalog_coverage_ignores_off_catalog_recommendations():
+    catalog = {"a", "b"}
+    predicted = [["a", "ghost"]]
+    # "ghost" is dropped; only "a" hits the catalog → 1/2
+    assert catalog_coverage(predicted, catalog, k=2) == pytest.approx(0.5)
+
+
+def test_serendipity_worked_example():
+    # truth = {A, B}; expected = {A, X}; predicted = [A, B, C], k=3
+    # A: relevant but expected → not serendipitous
+    # B: relevant and unexpected → serendipitous
+    # C: not relevant → no
+    # hits = 1 → score = 1/3
+    predicted = [["A", "B", "C"]]
+    actual = [{"A", "B"}]
+    expected = [{"A", "X"}]
+    assert serendipity_at_k(predicted, actual, expected, k=3) == pytest.approx(1 / 3)
+
+
+def test_serendipity_empty_expected_is_just_relevance():
+    predicted = [["A", "B", "C"]]
+    actual = [{"A", "B"}]
+    expected = [set()]
+    # nothing is "expected", so every relevant hit is serendipitous → 2/3
+    assert serendipity_at_k(predicted, actual, expected, k=3) == pytest.approx(2 / 3)
+
+
+def test_serendipity_users_without_relevant_items_are_skipped():
+    predicted = [["A"], ["B"]]
+    actual = [{"A"}, set()]
+    expected = [set(), set()]
+    # only user 1 contributes → 1/1 = 1.0
+    assert serendipity_at_k(predicted, actual, expected, k=1) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "metric, args",
+    [
+        (intra_list_diversity, ([["a"]], _toy_similarity)),
+        (novelty, ([["a"]], {"a": 0.5})),
+        (catalog_coverage, ([["a"]], {"a"})),
+    ],
+)
+def test_beyond_accuracy_invalid_k_raises(metric, args):
+    with pytest.raises(ValueError, match="k must be positive"):
+        metric(*args, k=0)
+
+
+def test_serendipity_invalid_k_raises():
+    with pytest.raises(ValueError, match="k must be positive"):
+        serendipity_at_k([["a"]], [{"a"}], [set()], k=0)
+
+
+def test_serendipity_mismatched_lengths_raise():
+    with pytest.raises(ValueError, match="same length"):
+        serendipity_at_k([["a"], ["b"]], [{"a"}], [set()], k=1)


### PR DESCRIPTION
Adds four pure functions to `recommender_systems.metrics` that measure recommendation quality along axes pure accuracy can't see. Same per-user shape as the existing ranking metrics, same worked-example testing style.

## What's new

- `intra_list_diversity(predicted, similarity, k)` — macro average of `1 - similarity(a, b)` over all distinct pairs in each user's top-k. Caller supplies a symmetric similarity callable, so any item-similarity model (TF-IDF, embeddings, etc.) plugs in.
- `novelty(predicted, item_popularity, k)` — mean self-information `-log2(p_i)` over recommended items, averaged across users. Items missing from the popularity map are skipped within a user's list; users whose whole top-k is unknown are skipped from the mean.
- `catalog_coverage(predicted, catalog, k)` — fraction of catalog items that appear in *any* user's top-k. Off-catalog recommendations are ignored.
- `serendipity_at_k(predicted, actual, expected, k)` — macro share of top-k that's both relevant and not in the user's `expected` baseline list (commonly a popularity recommender's output). Captures the difference between accurate-and-obvious and accurate-and-surprising.

## Tests

- Worked-example test per metric with hand-computed expected values.
- Skip-rules covered: singleton lists for diversity, all-unknown items for novelty, no-relevant users for serendipity.
- Validation: invalid `k` and mismatched lengths raise `ValueError`.

All 52 tests pass under ruff lint + format + pytest locally; metrics module stayed cohesive (one file, ~265 lines).

Closes #24