### PR TITLE
chore: add mypy and coverage reporting to CI, with README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -30,5 +33,13 @@ jobs:
         run: ruff check src tests
       - name: Format check
         run: ruff format --check src tests
+      - name: Type-check
+        run: mypy
       - name: Test
-        run: pytest
+        run: pytest --cov=recommender_systems --cov-report=term-missing --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Recommender Systems Library
+
+[![CI](https://github.com/Burton-David/Recommender-Systems/actions/workflows/ci.yml/badge.svg)](https://github.com/Burton-David/Recommender-Systems/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Burton-David/Recommender-Systems/branch/main/graph/badge.svg)](https://codecov.io/gh/Burton-David/Recommender-Systems)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+
 **This library contains a variety of different recommender systems implemented in Python.**
 
 1. user_based_cosine_similarity.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 embeddings = ["gensim>=4.3"]
 dev = [
+    "mypy>=1.8",
     "pytest>=7.4",
     "pytest-cov>=4.1",
     "ruff>=0.4",
@@ -64,3 +65,24 @@ minversion = "7.0"
 addopts = "-ra --strict-markers"
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src"]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_ignores = true
+ignore_missing_imports = true
+
+[tool.coverage.run]
+source = ["recommender_systems"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+precision = 1


### PR DESCRIPTION
Engineering polish that's visible at a glance on the repo page.

## What changed

- **mypy** — reasonably strict config (`disallow_untyped_defs`, `check_untyped_defs`, `warn_return_any`, `no_implicit_optional`). Passes cleanly on the existing source. `ignore_missing_imports` keeps third-party libraries (pandas, numpy, sklearn) from drowning out real signal.
- **Coverage** — `pytest --cov=recommender_systems --cov-report=term-missing --cov-report=xml`; baseline on `main` is ~95%. The 3.12 matrix leg uploads to Codecov; the other legs skip the upload to avoid duplicates.
- **CI hardening** — workflow pinned to least-privilege `permissions: contents: read`.
- **README badges** — CI status, Codecov, Python version, license, Ruff, mypy. The Codecov badge will read "unknown" until the repository is enrolled at codecov.io (one-click once Burton-David signs in there).

## Local results

```
ruff check src tests          # clean
ruff format --check src tests # clean
mypy                          # Success: no issues found in 6 source files
pytest --cov                  # 34 passed, 94.9% coverage
```

CI matrix retains the existing `test (3.10/3.11/3.12)` job names so the required-status-check rules continue to apply without reconfiguration.

Closes #25