### PR TITLE
Add user/item k-NN collaborative filtering

### DIFF
--- a/src/recommender_systems/neighborhood.py
+++ b/src/recommender_systems/neighborhood.py
@@ -57,18 +57,18 @@ class ItemKNN(_NeighborhoodCF):
     """Score items by similarity to the items a user has already rated."""
 
     def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
-        return cosine_similarity(matrix.T)
+        return np.asarray(cosine_similarity(matrix.T))
 
     def _scores(self, user_id: Hashable) -> np.ndarray:
-        return self._similarity @ self._matrix.loc[user_id].to_numpy()
+        return np.asarray(self._similarity @ self._matrix.loc[user_id].to_numpy())
 
 
 class UserKNN(_NeighborhoodCF):
     """Score items by the ratings of a user's nearest neighbors."""
 
     def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
-        return cosine_similarity(matrix)
+        return np.asarray(cosine_similarity(matrix))
 
     def _scores(self, user_id: Hashable) -> np.ndarray:
         weights = self._similarity[self._matrix.index.get_loc(user_id)]
-        return weights @ self._matrix.to_numpy() / (weights.sum() or 1.0)
+        return np.asarray(weights @ self._matrix.to_numpy() / (weights.sum() or 1.0))

--- a/src/recommender_systems/neighborhood.py
+++ b/src/recommender_systems/neighborhood.py
@@ -1,0 +1,74 @@
+"""Neighborhood (k-NN) collaborative filtering."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Hashable
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics.pairwise import cosine_similarity
+
+from recommender_systems.base import Recommender
+from recommender_systems.data import build_user_item_matrix
+
+__all__ = ["ItemKNN", "UserKNN"]
+
+
+def _keep_top_k(similarity: np.ndarray, k: int) -> np.ndarray:
+    """Zero the diagonal and all but the ``k`` largest entries in each row."""
+    similarity = similarity.copy()
+    np.fill_diagonal(similarity, 0.0)
+    if k < similarity.shape[1]:
+        drop = np.argsort(-similarity, axis=1)[:, k:]
+        np.put_along_axis(similarity, drop, 0.0, axis=1)
+    return similarity
+
+
+class _NeighborhoodCF(Recommender):
+    """Shared fit/recommend for neighborhood collaborative filtering."""
+
+    def __init__(self, k: int = 20) -> None:
+        self.k = k
+        self._matrix = pd.DataFrame()
+        self._similarity = np.empty((0, 0))
+
+    def fit(self, ratings: pd.DataFrame) -> _NeighborhoodCF:
+        self._matrix = build_user_item_matrix(ratings, fill_value=0.0)
+        self._similarity = _keep_top_k(self._similarity_of(self._matrix.to_numpy()), self.k)
+        return self
+
+    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
+        if user_id not in self._matrix.index:
+            return []
+        scores = self._scores(user_id)
+        scores[self._matrix.loc[user_id].to_numpy() > 0] = -np.inf
+        order = np.argsort(-scores)
+        return [self._matrix.columns[i] for i in order if np.isfinite(scores[i])][:n]
+
+    @abstractmethod
+    def _similarity_of(self, matrix: np.ndarray) -> np.ndarray: ...
+
+    @abstractmethod
+    def _scores(self, user_id: Hashable) -> np.ndarray: ...
+
+
+class ItemKNN(_NeighborhoodCF):
+    """Score items by similarity to the items a user has already rated."""
+
+    def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
+        return cosine_similarity(matrix.T)
+
+    def _scores(self, user_id: Hashable) -> np.ndarray:
+        return self._similarity @ self._matrix.loc[user_id].to_numpy()
+
+
+class UserKNN(_NeighborhoodCF):
+    """Score items by the ratings of a user's nearest neighbors."""
+
+    def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
+        return cosine_similarity(matrix)
+
+    def _scores(self, user_id: Hashable) -> np.ndarray:
+        weights = self._similarity[self._matrix.index.get_loc(user_id)]
+        return weights @ self._matrix.to_numpy() / (weights.sum() or 1.0)

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from recommender_systems.base import Recommender
+from recommender_systems.neighborhood import ItemKNN, UserKNN
+
+
+def sample_ratings():
+    # users 1 and 2 overlap on a, b; user 2 also rated c; user 3 is isolated on d.
+    return pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 2, 2, 3],
+            "item_id": ["a", "b", "a", "b", "c", "d"],
+            "rating": [5, 5, 5, 5, 5, 5],
+        }
+    )
+
+
+def test_knn_implement_interface():
+    assert issubclass(ItemKNN, Recommender)
+    assert issubclass(UserKNN, Recommender)
+
+
+def test_item_knn_recommends_cooccurring_item():
+    # c co-occurs with a and b, which user 1 has rated -> c is the top unseen item.
+    model = ItemKNN().fit(sample_ratings())
+    assert model.recommend(1, n=1) == ["c"]
+
+
+def test_user_knn_recommends_from_nearest_neighbor():
+    # user 2 is user 1's nearest neighbor and rated c -> c is recommended.
+    model = UserKNN().fit(sample_ratings())
+    assert model.recommend(1, n=1) == ["c"]
+
+
+def test_unknown_user_returns_empty():
+    assert UserKNN().fit(sample_ratings()).recommend(999) == []


### PR DESCRIPTION
Neighborhood collaborative filtering on the `Recommender` interface.

- `UserKNN` — scores items from a user's nearest neighbors.
- `ItemKNN` — scores items by similarity to what the user already rated.
- Shared core: cosine similarity, configurable top-`k` neighborhood, excludes seen items. Tested with worked examples.

**Consolidation:** a general UserKNN/ItemKNN covers the two separate cosine-CF migrations, so this supersedes them rather than adding near-duplicate modules.

Closes #9
Closes #10
Closes #14