### PR TITLE
Rename train_test_split to split_ratings

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -1,8 +1,8 @@
 """Recommender Systems: classic and modern recommendation algorithms."""
 
 from recommender_systems.base import Recommender
-from recommender_systems.data import build_user_item_matrix, train_test_split
+from recommender_systems.data import build_user_item_matrix, split_ratings
 
 __version__ = "0.1.0"
 
-__all__ = ["Recommender", "build_user_item_matrix", "train_test_split"]
+__all__ = ["Recommender", "build_user_item_matrix", "split_ratings"]

--- a/src/recommender_systems/data.py
+++ b/src/recommender_systems/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-__all__ = ["build_user_item_matrix", "train_test_split"]
+__all__ = ["build_user_item_matrix", "split_ratings"]
 
 
 def build_user_item_matrix(
@@ -44,7 +44,7 @@ def build_user_item_matrix(
     return matrix
 
 
-def train_test_split(
+def split_ratings(
     ratings: pd.DataFrame,
     *,
     test_size: float = 0.2,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from recommender_systems import build_user_item_matrix, train_test_split
+from recommender_systems import build_user_item_matrix, split_ratings
 
 
 @pytest.fixture
@@ -40,14 +40,14 @@ def test_matrix_missing_column_raises():
 
 
 def test_split_sizes_and_partition(ratings):
-    train, test = train_test_split(ratings, test_size=0.5, random_state=0)
+    train, test = split_ratings(ratings, test_size=0.5, random_state=0)
     assert len(test) == 2
     assert len(train) + len(test) == len(ratings)
 
 
 def test_split_is_reproducible(ratings):
-    a_train, a_test = train_test_split(ratings, test_size=0.5, random_state=42)
-    b_train, b_test = train_test_split(ratings, test_size=0.5, random_state=42)
+    a_train, a_test = split_ratings(ratings, test_size=0.5, random_state=42)
+    b_train, b_test = split_ratings(ratings, test_size=0.5, random_state=42)
     pd.testing.assert_frame_equal(a_train, b_train)
     pd.testing.assert_frame_equal(a_test, b_test)
 
@@ -55,4 +55,4 @@ def test_split_is_reproducible(ratings):
 def test_split_invalid_size_raises(ratings):
     for bad in (0.0, 1.0, -0.1, 1.5):
         with pytest.raises(ValueError, match="test_size"):
-            train_test_split(ratings, test_size=bad)
+            split_ratings(ratings, test_size=bad)


### PR DESCRIPTION
Resolves the naming collision burton flagged: `recommender_systems.split_ratings` no longer shadows `sklearn.model_selection.train_test_split`, and the name better describes what it splits. Updated the export and tests; mypy/ruff/pytest green.

Closes #28