### PR TITLE
refactor: rename train_test_split to split_interactions

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -1,8 +1,8 @@
 """Recommender Systems: classic and modern recommendation algorithms."""
 
 from recommender_systems.base import Recommender
-from recommender_systems.data import build_user_item_matrix, train_test_split
+from recommender_systems.data import build_user_item_matrix, split_interactions
 
 __version__ = "0.1.0"
 
-__all__ = ["Recommender", "build_user_item_matrix", "train_test_split"]
+__all__ = ["Recommender", "build_user_item_matrix", "split_interactions"]

--- a/src/recommender_systems/data.py
+++ b/src/recommender_systems/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-__all__ = ["build_user_item_matrix", "train_test_split"]
+__all__ = ["build_user_item_matrix", "split_interactions"]
 
 
 def build_user_item_matrix(
@@ -44,13 +44,16 @@ def build_user_item_matrix(
     return matrix
 
 
-def train_test_split(
+def split_interactions(
     ratings: pd.DataFrame,
     *,
     test_size: float = 0.2,
     random_state: int | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Split interactions into train and test sets by random row sampling.
+
+    Named ``split_interactions`` rather than ``train_test_split`` so it never
+    collides with the differently-shaped ``sklearn.model_selection.train_test_split``.
 
     Parameters
     ----------

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from recommender_systems import build_user_item_matrix, train_test_split
+from recommender_systems import build_user_item_matrix, split_interactions
 
 
 @pytest.fixture
@@ -40,14 +40,14 @@ def test_matrix_missing_column_raises():
 
 
 def test_split_sizes_and_partition(ratings):
-    train, test = train_test_split(ratings, test_size=0.5, random_state=0)
+    train, test = split_interactions(ratings, test_size=0.5, random_state=0)
     assert len(test) == 2
     assert len(train) + len(test) == len(ratings)
 
 
 def test_split_is_reproducible(ratings):
-    a_train, a_test = train_test_split(ratings, test_size=0.5, random_state=42)
-    b_train, b_test = train_test_split(ratings, test_size=0.5, random_state=42)
+    a_train, a_test = split_interactions(ratings, test_size=0.5, random_state=42)
+    b_train, b_test = split_interactions(ratings, test_size=0.5, random_state=42)
     pd.testing.assert_frame_equal(a_train, b_train)
     pd.testing.assert_frame_equal(a_test, b_test)
 
@@ -55,4 +55,4 @@ def test_split_is_reproducible(ratings):
 def test_split_invalid_size_raises(ratings):
     for bad in (0.0, 1.0, -0.1, 1.5):
         with pytest.raises(ValueError, match="test_size"):
-            train_test_split(ratings, test_size=bad)
+            split_interactions(ratings, test_size=bad)


### PR DESCRIPTION
Eliminates the name collision with `sklearn.model_selection.train_test_split`, flagged as a follow-up in #26's review and tracked in #28.

Even though the two functions live in different namespaces, the shared name made the import statement misleading and surprising:

```python
from recommender_systems import train_test_split   # (ratings) -> (train_df, test_df)
from sklearn.model_selection import train_test_split  # (X, y, *, stratify) -> (X_train, X_test, y_train, y_test)
```

After:

```python
from recommender_systems import split_interactions  # unambiguous; can't be confused
```

## Changes

- `recommender_systems.data.split_interactions` replaces `train_test_split`.
- `__init__.py` re-export and `__all__` updated.
- `tests/test_data.py` updated.
- Docstring on the renamed function records the rationale so the question doesn't get re-litigated later.

## Why now (no consumers yet)

Safe to do before the rest of the package starts importing it — once the migrations and benchmark land, the name would be much harder to change without breaking call sites.

## Local results

```
ruff check src tests          # clean
ruff format --check src tests # clean
mypy                          # Success: no issues found in 7 source files
pytest                        # 55 passed
```

Closes #28