### PR TITLE
docs: publish a Material for MkDocs site to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+      - name: Build site
+        run: mkdocs build --strict --site-dir _site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Recommender Systems Library
 
 [![CI](https://github.com/Burton-David/Recommender-Systems/actions/workflows/ci.yml/badge.svg)](https://github.com/Burton-David/Recommender-Systems/actions/workflows/ci.yml)
+[![Docs](https://github.com/Burton-David/Recommender-Systems/actions/workflows/docs.yml/badge.svg)](https://burton-david.github.io/Recommender-Systems/)
 [![codecov](https://codecov.io/gh/Burton-David/Recommender-Systems/branch/main/graph/badge.svg)](https://codecov.io/gh/Burton-David/Recommender-Systems)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,33 @@
+# API Reference
+
+## Common interface
+
+::: recommender_systems.base
+
+## Recommenders
+
+### Baselines
+
+::: recommender_systems.baselines
+
+### Neighborhood collaborative filtering
+
+::: recommender_systems.neighborhood
+
+### Matrix factorization
+
+::: recommender_systems.svd
+
+## Data
+
+### Loading benchmarks
+
+::: recommender_systems.datasets
+
+### Preparing interaction data
+
+::: recommender_systems.data
+
+## Evaluation metrics
+
+::: recommender_systems.metrics

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# Recommender Systems
+
+A collection of classic and modern recommender system algorithms with a clean,
+unified API.
+
+## Highlights
+
+- **One interface.** Every algorithm implements `fit(ratings)` and
+  `recommend(user, n)`, so they're interchangeable.
+- **Five algorithms out of the box.** `MostPopular`, `MeanRating`, `UserKNN`,
+  `ItemKNN`, `SVD` — more on the way.
+- **Evaluation built-in.** `precision@k`, `recall@k`, `MAP`, `NDCG`, plus
+  beyond-accuracy metrics (intra-list diversity, novelty, catalog coverage,
+  serendipity).
+- **Datasets.** `load_movielens_100k()` downloads and caches the standard
+  benchmark; CI tests stay offline.
+- **Typed, tested, ruff-clean.** Python 3.10+; pandas / numpy / scikit-learn
+  under the hood.
+
+## Install
+
+```bash
+pip install recommender-systems
+```
+
+For the optional word-embeddings recommender:
+
+```bash
+pip install 'recommender-systems[embeddings]'
+```
+
+See [Quickstart](quickstart.md) for a worked example, or
+[API Reference](api.md) for the full surface.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart
+
+A complete fit → recommend → evaluate flow on MovieLens 100k.
+
+```python
+from recommender_systems import split_ratings
+from recommender_systems.datasets import load_movielens_100k
+from recommender_systems.svd import SVD
+from recommender_systems.metrics import ndcg_at_k, precision_at_k
+
+# 1. Load and split.
+ratings = load_movielens_100k()
+train, test = split_ratings(ratings, test_size=0.2, random_state=0)
+
+# 2. Fit.
+model = SVD(n_factors=50, random_state=0).fit(train)
+
+# 3. Recommend for the held-out users.
+test_users = test["user_id"].unique()
+predicted = [model.recommend(u, n=10) for u in test_users]
+
+# 4. Evaluate against the holdout.
+truth = test.groupby("user_id")["item_id"].agg(set)
+actual = [truth.get(u, set()) for u in test_users]
+
+print(f"precision@10 = {precision_at_k(predicted, actual, k=10):.3f}")
+print(f"NDCG@10      = {ndcg_at_k(predicted, actual, k=10):.3f}")
+```
+
+Swap `SVD(...)` for `UserKNN()`, `ItemKNN()`, `MostPopular()`, or
+`MeanRating()` — every recommender exposes the same `fit` / `recommend`
+contract, so the rest of the script is unchanged.
+
+## Beyond accuracy
+
+The same `predicted` and `actual` lists feed the beyond-accuracy metrics:
+
+```python
+from recommender_systems.metrics import catalog_coverage, novelty
+
+catalog = ratings["item_id"].unique()
+counts = ratings["item_id"].value_counts(normalize=True).to_dict()
+
+print(f"coverage@10 = {catalog_coverage(predicted, catalog, k=10):.3f}")
+print(f"novelty@10  = {novelty(predicted, counts, k=10):.2f}")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: Recommender Systems
+site_description: A collection of classic and modern recommender system algorithms.
+site_url: https://burton-david.github.io/Recommender-Systems/
+repo_url: https://github.com/Burton-David/Recommender-Systems
+repo_name: Burton-David/Recommender-Systems
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.tracking
+    - navigation.top
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: numpy
+            show_source: false
+            show_root_heading: true
+            show_signature_annotations: true
+            separate_signature: true
+            members_order: source
+            merge_init_into_class: true
+            heading_level: 3
+
+nav:
+  - Overview: index.md
+  - Quickstart: quickstart.md
+  - API Reference: api.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 embeddings = ["gensim>=4.3"]
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.24",
+]
 dev = [
     "mypy>=1.8",
     "pytest>=7.4",


### PR DESCRIPTION
A real documentation site, auto-generated from the source docstrings, so the public API surface is browsable instead of buried in the README.

## What's added

- **`mkdocs.yml`** — Material theme with light/dark toggle, code copy, mkdocstrings/python pulling the existing NumPy-style docstrings straight from the package. Three-page nav: Overview → Quickstart → API Reference.
- **`docs/index.md`** — overview with the package's selling points.
- **`docs/quickstart.md`** — complete load → split → fit → recommend → evaluate flow against MovieLens 100k, plus a beyond-accuracy example.
- **`docs/api.md`** — full API reference auto-generated from the docstrings (covers `base`, `baselines`, `neighborhood`, `svd`, `datasets`, `data`, `metrics`).
- **`.github/workflows/docs.yml`** — `mkdocs build --strict` for catch-broken-links, then deploy via the modern `actions/deploy-pages` flow (no `gh-pages` branch needed).
- **README** — new Docs badge.
- **`pyproject.toml`** — new `docs` optional-dependency group (`mkdocs-material`, `mkdocstrings[python]`). The CI workflow stays untouched; only the docs workflow installs these.

## One-time GitHub setup

The repo needs Pages enabled with "GitHub Actions" as the source. Settings → Pages → Source: "GitHub Actions". After this lands and the workflow runs once, the site goes live at <https://burton-david.github.io/Recommender-Systems/> and the README's Docs badge will point at it.

## Local verification

```
mkdocs build --strict          # clean (one informational note about MkDocs 2.0 ecosystem, not actionable)
ruff check src tests            # clean
ruff format --check src tests   # clean
mypy                            # Success: no issues found in 8 source files
pytest                          # 59 passed
```

Closes #22