### PR TITLE
refactor: extract _MatrixBackedRecommender base for shared recommend() logic

### DIFF
--- a/src/recommender_systems/base.py
+++ b/src/recommender_systems/base.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Hashable
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import pandas as pd
+import numpy as np
+import pandas as pd
 
 __all__ = ["Recommender"]
 
@@ -51,3 +50,28 @@ class Recommender(ABC):
         list of Hashable
             Item ids ordered from most to least recommended.
         """
+
+
+class _MatrixBackedRecommender(Recommender):
+    """Recommend by ranking the user's row of a materialized user-item matrix.
+
+    Subclasses fill in :meth:`fit` (which must set ``self._matrix``) and
+    :meth:`_user_scores`, an item-aligned numpy vector. This base owns the
+    unknown-user fast path, the seen-item mask, and the top-``n`` filter, so
+    every matrix-backed algorithm shares one recommend contract.
+    """
+
+    def __init__(self) -> None:
+        self._matrix = pd.DataFrame()
+
+    @abstractmethod
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        """Return an item-aligned score vector for ``user_id``."""
+
+    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
+        if user_id not in self._matrix.index:
+            return []
+        scores = self._user_scores(user_id).copy()
+        scores[self._matrix.loc[user_id].to_numpy() > 0] = -np.inf
+        order = np.argsort(-scores)
+        return [self._matrix.columns[i] for i in order if np.isfinite(scores[i])][:n]

--- a/src/recommender_systems/neighborhood.py
+++ b/src/recommender_systems/neighborhood.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
 
-from recommender_systems.base import Recommender
+from recommender_systems.base import _MatrixBackedRecommender
 from recommender_systems.data import build_user_item_matrix
 
 __all__ = ["ItemKNN", "UserKNN"]
@@ -25,12 +25,12 @@ def _keep_top_k(similarity: np.ndarray, k: int) -> np.ndarray:
     return similarity
 
 
-class _NeighborhoodCF(Recommender):
-    """Shared fit/recommend for neighborhood collaborative filtering."""
+class _NeighborhoodCF(_MatrixBackedRecommender):
+    """Shared fit for neighborhood collaborative filtering."""
 
     def __init__(self, k: int = 20) -> None:
+        super().__init__()
         self.k = k
-        self._matrix = pd.DataFrame()
         self._similarity = np.empty((0, 0))
 
     def fit(self, ratings: pd.DataFrame) -> _NeighborhoodCF:
@@ -38,19 +38,8 @@ class _NeighborhoodCF(Recommender):
         self._similarity = _keep_top_k(self._similarity_of(self._matrix.to_numpy()), self.k)
         return self
 
-    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
-        if user_id not in self._matrix.index:
-            return []
-        scores = self._scores(user_id)
-        scores[self._matrix.loc[user_id].to_numpy() > 0] = -np.inf
-        order = np.argsort(-scores)
-        return [self._matrix.columns[i] for i in order if np.isfinite(scores[i])][:n]
-
     @abstractmethod
     def _similarity_of(self, matrix: np.ndarray) -> np.ndarray: ...
-
-    @abstractmethod
-    def _scores(self, user_id: Hashable) -> np.ndarray: ...
 
 
 class ItemKNN(_NeighborhoodCF):
@@ -59,7 +48,7 @@ class ItemKNN(_NeighborhoodCF):
     def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
         return np.asarray(cosine_similarity(matrix.T))
 
-    def _scores(self, user_id: Hashable) -> np.ndarray:
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
         return np.asarray(self._similarity @ self._matrix.loc[user_id].to_numpy())
 
 
@@ -69,6 +58,6 @@ class UserKNN(_NeighborhoodCF):
     def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
         return np.asarray(cosine_similarity(matrix))
 
-    def _scores(self, user_id: Hashable) -> np.ndarray:
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
         weights = self._similarity[self._matrix.index.get_loc(user_id)]
         return np.asarray(weights @ self._matrix.to_numpy() / (weights.sum() or 1.0))

--- a/src/recommender_systems/svd.py
+++ b/src/recommender_systems/svd.py
@@ -8,13 +8,13 @@ import numpy as np
 import pandas as pd
 from sklearn.decomposition import TruncatedSVD
 
-from recommender_systems.base import Recommender
+from recommender_systems.base import _MatrixBackedRecommender
 from recommender_systems.data import build_user_item_matrix
 
 __all__ = ["SVD"]
 
 
-class SVD(Recommender):
+class SVD(_MatrixBackedRecommender):
     """Recommend from a low-rank reconstruction of the user-item matrix.
 
     Parameters
@@ -26,9 +26,9 @@ class SVD(Recommender):
     """
 
     def __init__(self, n_factors: int = 20, random_state: int | None = None) -> None:
+        super().__init__()
         self.n_factors = n_factors
         self.random_state = random_state
-        self._matrix = pd.DataFrame()
         self._predicted = np.empty((0, 0))
 
     def fit(self, ratings: pd.DataFrame) -> SVD:
@@ -39,10 +39,5 @@ class SVD(Recommender):
         self._predicted = factors @ model.components_
         return self
 
-    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
-        if user_id not in self._matrix.index:
-            return []
-        scores = self._predicted[self._matrix.index.get_loc(user_id)].copy()
-        scores[self._matrix.loc[user_id].to_numpy() > 0] = -np.inf
-        order = np.argsort(-scores)
-        return [self._matrix.columns[i] for i in order if np.isfinite(scores[i])][:n]
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])


### PR DESCRIPTION
Pulls the duplicated `recommend()` body from `SVD` and the kNN base into a single `_MatrixBackedRecommender` in `base.py`. Subclasses now supply only `fit()` (which sets `self._matrix`) and `_user_scores(user_id)`, the item-aligned score vector.

The base owns the unknown-user fast path, the seen-item `-inf` mask, and the top-n / `np.isfinite` filter, so every matrix-backed algorithm follows one contract — and any new algorithm with the same data shape (ALS, BPR, neural CF) only needs ~10 lines of glue to plug in.

## Diff shape

```
 src/recommender_systems/base.py         | 30 +++++++++++++++++++++++++++---
 src/recommender_systems/neighborhood.py | 23 ++++++-----------------
 src/recommender_systems/svd.py          | 15 +++++----------
 3 files changed, 38 insertions(+), 30 deletions(-)
```

Net is roughly flat in line count, but standardizes the contract and removes two near-identical `recommend()` bodies.

## Acceptance criteria from #35

- [x] New `_MatrixBackedRecommender` private base (kept in `base.py` per the "few cohesive modules" preference).
- [x] `SVD` and `UserKNN`/`ItemKNN` rewritten to provide only `fit()` and `_user_scores()`.
- [x] No behavior change: all 59 tests pass unchanged.
- [x] No public-API change — `_MatrixBackedRecommender` is private; only `Recommender` is exported.

## Local checks

```
ruff check src tests          # clean
ruff format --check src tests # clean
mypy                          # Success: no issues found in 8 source files
pytest                        # 59 passed
```

Closes #35