### PR TITLE
feat: side-information convention plus a reference ContentBased recommender

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,24 @@ The package uses a `src/` layout; the importable package is `recommender_systems
 - Prefer small, pure functions and explicit arguments over hidden state. No code should
   run at import time.
 
+## Recommenders that need side information
+
+Some algorithms — content-based, demographic, context-aware — need data beyond the
+ratings frame: item features, user attributes, or context. Keep `fit(ratings)` uniform
+across the library so algorithms remain interchangeable, and **pass side information
+through the constructor** instead of adding a parameter to `fit`:
+
+```python
+recommender = ContentBased(item_features=features)
+recommender.fit(ratings)
+```
+
+This puts the algorithm's static configuration — the *kind* of side information it
+consumes — in its identity, while the per-training-run signal stays on `fit`. Evaluation
+harnesses and benchmark scripts can then iterate over a list of fully-constructed
+recommenders without branching on signature differences. See
+`recommender_systems.content.ContentBased` for the reference implementation.
+
 ## Tests
 
 - Every algorithm and bug fix ships with tests under `tests/`.

--- a/src/recommender_systems/content.py
+++ b/src/recommender_systems/content.py
@@ -1,0 +1,56 @@
+"""Content-based recommendation by item-feature similarity."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics.pairwise import cosine_similarity
+
+from recommender_systems.base import _MatrixBackedRecommender
+from recommender_systems.data import build_user_item_matrix
+
+__all__ = ["ContentBased"]
+
+
+class ContentBased(_MatrixBackedRecommender):
+    """Recommend items whose features resemble those a user has liked.
+
+    The user's profile is a ratings-weighted mean of the features of the items they
+    rated; recommendations are ranked by cosine similarity between that profile and
+    each candidate item.
+
+    Side information is passed at **construction time** rather than to ``fit``. This
+    keeps ``fit(ratings)`` uniform across the library so algorithms stay interchangeable;
+    see ``CONTRIBUTING.md`` for the convention.
+
+    Parameters
+    ----------
+    item_features
+        DataFrame indexed by item id with one numerical feature per column.
+        Callers pre-compute features from raw inputs (TF-IDF over descriptions,
+        embeddings, one-hot categoricals, etc.) before passing them in.
+    """
+
+    def __init__(self, item_features: pd.DataFrame) -> None:
+        super().__init__()
+        self._item_features = item_features
+        self._predicted = np.empty((0, 0))
+
+    def fit(self, ratings: pd.DataFrame) -> ContentBased:
+        rated_matrix = build_user_item_matrix(ratings, fill_value=0.0)
+        # Items with features but no ratings still need to be recommendable —
+        # that's the whole point of content-based — so widen the matrix to the
+        # union of rated and featured items.
+        item_space = rated_matrix.columns.union(self._item_features.index)
+        self._matrix = rated_matrix.reindex(columns=item_space, fill_value=0.0)
+        features = self._item_features.reindex(self._matrix.columns).fillna(0.0).to_numpy()
+        weights = self._matrix.to_numpy()
+        row_sums = weights.sum(axis=1, keepdims=True)
+        profiles = np.divide(weights @ features, np.where(row_sums == 0, 1.0, row_sums))
+        self._predicted = np.asarray(cosine_similarity(profiles, features))
+        return self
+
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,62 @@
+import pandas as pd
+
+from recommender_systems.base import Recommender
+from recommender_systems.content import ContentBased
+
+
+def sample_ratings():
+    # user 1 rated action films a and b; user 2 rated drama c; item d is action.
+    return pd.DataFrame(
+        {
+            "user_id": [1, 1, 2],
+            "item_id": ["a", "b", "c"],
+            "rating": [5, 5, 5],
+        }
+    )
+
+
+def sample_item_features():
+    return pd.DataFrame(
+        {"action": [1.0, 1.0, 0.0, 1.0], "drama": [0.0, 0.0, 1.0, 0.0]},
+        index=["a", "b", "c", "d"],
+    )
+
+
+def test_content_based_implements_interface():
+    assert issubclass(ContentBased, Recommender)
+
+
+def test_constructor_takes_side_information():
+    # The convention test: side information arrives via the constructor; fit takes
+    # only the ratings frame, exactly like every other recommender in the library.
+    model = ContentBased(item_features=sample_item_features())
+    model.fit(sample_ratings())  # signature parity with all other recommenders
+    assert model.recommend(1, n=1) == ["d"]
+
+
+def test_recommends_by_feature_similarity():
+    # User 1's profile is pure action; the only unseen action item is d.
+    model = ContentBased(sample_item_features()).fit(sample_ratings())
+    assert model.recommend(1, n=2) == ["d", "c"]
+
+
+def test_excludes_seen_items():
+    model = ContentBased(sample_item_features()).fit(sample_ratings())
+    recs = model.recommend(1, n=10)
+    assert "a" not in recs
+    assert "b" not in recs
+
+
+def test_unknown_user_returns_empty():
+    model = ContentBased(sample_item_features()).fit(sample_ratings())
+    assert model.recommend(999) == []
+
+
+def test_handles_items_missing_from_features():
+    # Items present in ratings but absent from item_features are zero-filled,
+    # so they're still recommendable but score as having no signal.
+    ratings = sample_ratings()
+    partial_features = sample_item_features().drop(index=["c"])
+    model = ContentBased(partial_features).fit(ratings)
+    # User 1 still prefers d (the action item that's in the feature table).
+    assert model.recommend(1, n=1) == ["d"]


### PR DESCRIPTION
Closes #37, which JJ filed because the still-blocked migrations (#11 content-based, #12 demographic/context/hybrid) need data beyond the ratings frame, but `Recommender.fit(ratings)` only carries interactions.

## The convention

Pass side information **through the constructor**, keep `fit(ratings)` uniform:

```python
recommender = ContentBased(item_features=features)
recommender.fit(ratings)
```

Documented in `CONTRIBUTING.md` under a new "Recommenders that need side information" section. The construction-time signal makes the algorithm's static configuration part of its identity, while the per-training-run signal stays on `fit` — so evaluation harnesses and benchmark scripts can iterate over a list of fully-constructed recommenders without branching on signature differences.

## Reference implementation

`recommender_systems.content.ContentBased` — minimal but real:

- Accepts `item_features: pd.DataFrame` at construction (caller pre-computes TF-IDF / embeddings / one-hot / etc.).
- User profile is the ratings-weighted mean of the features of rated items.
- Recommendations rank by cosine similarity between the user profile and each item.
- Subclasses `_MatrixBackedRecommender` (from #35), so it inherits the unknown-user / seen-mask / top-n contract.

One subtlety baked in: the item space is the **union** of items appearing in the ratings frame and items appearing in `item_features`. Without that union, featured-but-unrated items would be invisible to `recommend()` — which would defeat the whole point of content-based (it can score cold-start items that collaborative filtering can't). Covered by `test_handles_items_missing_from_features`.

## Tests (6 new, 65 total)

- Interface conformance.
- Convention check: side info goes through `__init__`, `fit` takes only ratings.
- Worked example: user 1 rates two action items, prefers the unseen action item over the unseen drama item.
- Seen items are excluded.
- Unknown users get `[]`.
- Items missing from features are still recommendable (zero-similarity).

## Local checks

```
ruff check src tests           # clean
ruff format --check src tests  # clean
mypy                           # Success: no issues found in 9 source files
pytest                         # 65 passed
```

Closes #37