### PR TITLE
Add goodbooks-10k dataset loaders

### DIFF
--- a/src/recommender_systems/datasets.py
+++ b/src/recommender_systems/datasets.py
@@ -8,11 +8,17 @@ from pathlib import Path
 
 import pandas as pd
 
-__all__ = ["load_movielens_100k"]
+__all__ = [
+    "load_goodbooks_10k",
+    "load_goodbooks_books",
+    "load_goodbooks_tags",
+    "load_movielens_100k",
+]
 
-_ML_100K_URL = "https://files.grouplens.org/datasets/movielens/ml-100k.zip"
 _DEFAULT_HOME = Path.home() / ".recommender_systems"
-_COLUMNS = ["user_id", "item_id", "rating", "timestamp"]
+_ML_100K_URL = "https://files.grouplens.org/datasets/movielens/ml-100k.zip"
+_ML_COLUMNS = ["user_id", "item_id", "rating", "timestamp"]
+_GOODBOOKS_BASE = "https://raw.githubusercontent.com/zygmuntz/goodbooks-10k/master"
 
 
 def load_movielens_100k(data_home: str | Path | None = None) -> pd.DataFrame:
@@ -31,13 +37,54 @@ def load_movielens_100k(data_home: str | Path | None = None) -> pd.DataFrame:
     home = Path(data_home) if data_home is not None else _DEFAULT_HOME
     data_file = home / "ml-100k" / "u.data"
     if not data_file.exists():
-        _download_and_extract(home)
-    return pd.read_csv(data_file, sep="\t", names=_COLUMNS)
+        home.mkdir(parents=True, exist_ok=True)
+        archive = home / "ml-100k.zip"
+        urllib.request.urlretrieve(_ML_100K_URL, archive)
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(home)
+    return pd.read_csv(data_file, sep="\t", names=_ML_COLUMNS)
 
 
-def _download_and_extract(home: Path) -> None:
-    home.mkdir(parents=True, exist_ok=True)
-    archive = home / "ml-100k.zip"
-    urllib.request.urlretrieve(_ML_100K_URL, archive)
-    with zipfile.ZipFile(archive) as zf:
-        zf.extractall(home)
+def load_goodbooks_10k(data_home: str | Path | None = None) -> pd.DataFrame:
+    """Load the goodbooks-10k ratings, downloading and caching on first use.
+
+    For the open-source benchmark/demo only: the dataset derives from Goodreads and is
+    not licensed for shipping in a commercial app (see the README).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Ratings with columns ``user_id``, ``book_id``, ``rating``.
+    """
+    return pd.read_csv(_goodbooks_file(data_home, "ratings.csv"))
+
+
+def load_goodbooks_books(data_home: str | Path | None = None) -> pd.DataFrame:
+    """Load goodbooks-10k book metadata (title, authors, ids, average rating, ...)."""
+    return pd.read_csv(_goodbooks_file(data_home, "books.csv"))
+
+
+def load_goodbooks_tags(data_home: str | Path | None = None) -> pd.DataFrame:
+    """Load goodbooks-10k tags joined to ``book_id`` and tag name.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns ``book_id``, ``tag_name``, ``count`` — ready to build content features.
+    """
+    book_tags = pd.read_csv(_goodbooks_file(data_home, "book_tags.csv"))
+    tags = pd.read_csv(_goodbooks_file(data_home, "tags.csv"))
+    ids = pd.read_csv(
+        _goodbooks_file(data_home, "books.csv"), usecols=["book_id", "goodreads_book_id"]
+    )
+    merged = book_tags.merge(tags, on="tag_id").merge(ids, on="goodreads_book_id")
+    return merged[["book_id", "tag_name", "count"]]
+
+
+def _goodbooks_file(data_home: str | Path | None, name: str) -> Path:
+    home = Path(data_home) if data_home is not None else _DEFAULT_HOME
+    path = home / "goodbooks-10k" / name
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(f"{_GOODBOOKS_BASE}/{name}", path)
+    return path

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,12 @@
-from recommender_systems.datasets import load_movielens_100k
+from recommender_systems.datasets import (
+    load_goodbooks_10k,
+    load_goodbooks_books,
+    load_goodbooks_tags,
+    load_movielens_100k,
+)
 
 
-def test_loads_cached_ratings_without_download(tmp_path):
+def test_movielens_loads_cached_ratings_without_download(tmp_path):
     extracted = tmp_path / "ml-100k"
     extracted.mkdir(parents=True)
     (extracted / "u.data").write_text(
@@ -13,3 +18,35 @@ def test_loads_cached_ratings_without_download(tmp_path):
     assert list(ratings.columns) == ["user_id", "item_id", "rating", "timestamp"]
     assert len(ratings) == 3
     assert ratings.loc[0, "rating"] == 5
+
+
+def _seed_goodbooks(root):
+    d = root / "goodbooks-10k"
+    d.mkdir(parents=True)
+    (d / "ratings.csv").write_text("user_id,book_id,rating\n1,1,5\n1,2,3\n2,1,4\n")
+    (d / "books.csv").write_text(
+        "book_id,goodreads_book_id,title\n1,100,Book One\n2,200,Book Two\n"
+    )
+    (d / "book_tags.csv").write_text("goodreads_book_id,tag_id,count\n100,10,5\n200,20,3\n")
+    (d / "tags.csv").write_text("tag_id,tag_name\n10,fantasy\n20,romance\n")
+
+
+def test_goodbooks_ratings_and_books_load_offline(tmp_path):
+    _seed_goodbooks(tmp_path)
+
+    ratings = load_goodbooks_10k(data_home=tmp_path)
+    assert list(ratings.columns) == ["user_id", "book_id", "rating"]
+    assert len(ratings) == 3
+
+    books = load_goodbooks_books(data_home=tmp_path)
+    assert "title" in books.columns
+
+
+def test_goodbooks_tags_join_to_book_id(tmp_path):
+    _seed_goodbooks(tmp_path)
+
+    tags = load_goodbooks_tags(data_home=tmp_path)
+
+    assert list(tags.columns) == ["book_id", "tag_name", "count"]
+    # book_id 1 -> goodreads_book_id 100 -> tag "fantasy"
+    assert tags.loc[tags["book_id"] == 1, "tag_name"].iloc[0] == "fantasy"


### PR DESCRIPTION
Foundation for the book-recommender showcase (epic #50, Phase 1).

- `load_goodbooks_10k` — ratings (`user_id`, `book_id`, `rating`)
- `load_goodbooks_books` — book metadata
- `load_goodbooks_tags` — tags joined to `book_id` (`book_id`, `tag_name`, `count`), ready for content features
- Same download-and-cache pattern as the MovieLens loader; all three tested offline via seeded fixtures (no network in CI).
- Docstring flags the dataset as benchmark/demo only — not for commercial shipping.

Unblocks the book benchmark (#43), content recommender (#44), and demo (#47).

Closes #42