### PR TITLE
feat: recsys CLI for recommendations and evaluation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
 Homepage = "https://github.com/Burton-David/Recommender-Systems"
 Repository = "https://github.com/Burton-David/Recommender-Systems"
 
+[project.scripts]
+recsys = "recommender_systems.cli:main"
+
 [tool.hatch.version]
 path = "src/recommender_systems/__init__.py"
 

--- a/src/recommender_systems/cli.py
+++ b/src/recommender_systems/cli.py
@@ -1,0 +1,129 @@
+"""Command-line interface for the recommender_systems library.
+
+Installed as the ``recsys`` console script via the project's ``[project.scripts]``
+entry point. Two subcommands so far::
+
+    recsys recommend --algo item-knn --user 42 --n 10
+    recsys evaluate  --algo svd
+
+Both train on MovieLens 100k (downloaded and cached on first use).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable, Sequence
+
+from recommender_systems import Recommender, split_ratings
+from recommender_systems.baselines import MeanRating, MostPopular
+from recommender_systems.datasets import load_movielens_100k
+from recommender_systems.metrics import (
+    mean_average_precision,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+)
+from recommender_systems.neighborhood import ItemKNN, UserKNN
+from recommender_systems.svd import SVD
+
+ALGORITHMS: dict[str, Callable[..., Recommender]] = {
+    "most-popular": MostPopular,
+    "mean-rating": MeanRating,
+    "item-knn": ItemKNN,
+    "user-knn": UserKNN,
+    "svd": SVD,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="recsys",
+        description="Train, recommend, and evaluate with recommender-systems.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for splits and stochastic models (default: 0)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True, metavar="<command>")
+
+    rec = sub.add_parser("recommend", help="Recommend items for a user")
+    rec.add_argument("--algo", choices=sorted(ALGORITHMS), required=True)
+    rec.add_argument("--user", type=int, required=True, help="User id to recommend for")
+    rec.add_argument("--n", type=int, default=10, help="How many items to return (default: 10)")
+
+    ev = sub.add_parser("evaluate", help="Train/test-split and report top-k metrics")
+    ev.add_argument("--algo", choices=sorted(ALGORITHMS), required=True)
+    ev.add_argument("--k", type=int, default=10, help="Cutoff for top-k metrics (default: 10)")
+    ev.add_argument(
+        "--test-size",
+        type=float,
+        default=0.2,
+        help="Fraction of rows held out for evaluation (default: 0.2)",
+    )
+
+    sub.add_parser("list-algos", help="Print the algorithms recsys knows about")
+
+    return parser
+
+
+def _instantiate(name: str, seed: int) -> Recommender:
+    factory = ALGORITHMS[name]
+    if name == "svd":
+        return factory(random_state=seed)
+    return factory()
+
+
+def _cmd_recommend(args: argparse.Namespace) -> int:
+    ratings = load_movielens_100k()
+    model = _instantiate(args.algo, args.seed).fit(ratings)
+    items = model.recommend(args.user, n=args.n)
+    if not items:
+        print(f"No recommendations for user {args.user}.", file=sys.stderr)
+        return 1
+    for rank, item in enumerate(items, start=1):
+        print(f"{rank}\t{item}")
+    return 0
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    ratings = load_movielens_100k()
+    train, test = split_ratings(ratings, test_size=args.test_size, random_state=args.seed)
+    model = _instantiate(args.algo, args.seed).fit(train)
+    truth = test.groupby("user_id")["item_id"].agg(set)
+    users = sorted(truth.index)
+    predicted = [model.recommend(u, n=args.k) for u in users]
+    actual = [truth[u] for u in users]
+    metrics = {
+        f"precision@{args.k}": precision_at_k(predicted, actual, args.k),
+        f"recall@{args.k}": recall_at_k(predicted, actual, args.k),
+        f"MAP@{args.k}": mean_average_precision(predicted, actual, args.k),
+        f"NDCG@{args.k}": ndcg_at_k(predicted, actual, args.k),
+    }
+    for name, value in metrics.items():
+        print(f"{name:14s} {value:.4f}")
+    return 0
+
+
+def _cmd_list_algos(_args: argparse.Namespace) -> int:
+    for name in sorted(ALGORITHMS):
+        print(name)
+    return 0
+
+
+COMMANDS: dict[str, Callable[[argparse.Namespace], int]] = {
+    "recommend": _cmd_recommend,
+    "evaluate": _cmd_evaluate,
+    "list-algos": _cmd_list_algos,
+}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return COMMANDS[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,82 @@
+import pandas as pd
+import pytest
+
+from recommender_systems import cli
+
+
+@pytest.fixture
+def fake_ratings(monkeypatch):
+    """Replace the MovieLens download with a tiny synthetic ratings frame."""
+
+    def _ratings(*_args, **_kwargs):
+        return pd.DataFrame(
+            {
+                "user_id": [1, 1, 2, 2, 3, 3, 3],
+                "item_id": ["a", "b", "a", "c", "a", "b", "c"],
+                "rating": [5, 4, 5, 3, 5, 2, 4],
+            }
+        )
+
+    monkeypatch.setattr(cli, "load_movielens_100k", _ratings)
+    return _ratings
+
+
+def test_list_algos(capsys):
+    code = cli.main(["list-algos"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "most-popular" in out
+    assert "svd" in out
+
+
+def test_recommend_prints_ranked_items(capsys, fake_ratings):
+    code = cli.main(["recommend", "--algo", "most-popular", "--user", "1", "--n", "1"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert out.strip().startswith("1\t")
+    assert len(out.strip().splitlines()) == 1
+
+
+def test_recommend_unknown_user_exits_nonzero(capsys, fake_ratings):
+    # item-knn returns [] for users absent from the trained matrix.
+    code = cli.main(["recommend", "--algo", "item-knn", "--user", "999"])
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "999" in err
+
+
+def test_evaluate_prints_metric_lines(capsys, fake_ratings):
+    code = cli.main(["evaluate", "--algo", "most-popular", "--k", "2", "--test-size", "0.3"])
+    out = capsys.readouterr().out
+    assert code == 0
+    names = [line.split()[0] for line in out.strip().splitlines()]
+    assert names == ["precision@2", "recall@2", "MAP@2", "NDCG@2"]
+
+
+def test_invalid_algo_exits_via_argparse():
+    with pytest.raises(SystemExit):
+        cli.main(["recommend", "--algo", "nonexistent", "--user", "1"])
+
+
+def test_missing_required_subcommand_exits():
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+
+def test_seed_propagates_to_svd(monkeypatch, fake_ratings):
+    seen = {}
+
+    class _Recorder:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+        def fit(self, _ratings):
+            return self
+
+        def recommend(self, *_args, **_kwargs):
+            return ["a"]
+
+    monkeypatch.setitem(cli.ALGORITHMS, "svd", _Recorder)
+    code = cli.main(["--seed", "42", "recommend", "--algo", "svd", "--user", "1", "--n", "1"])
+    assert code == 0
+    assert seen == {"random_state": 42}


### PR DESCRIPTION
Installs a `recsys` console script alongside the package so anyone with the install can kick the tires on every algorithm from a shell:

```bash
recsys recommend --algo item-knn --user 42 --n 10
recsys evaluate  --algo svd --k 10
recsys list-algos
```

## Design

- **`recommender_systems.cli`** — argparse-based, no extra deps.
  - `ALGORITHMS` is a single dict mapping kebab-case CLI name → factory. Adding an algorithm is one line.
  - `COMMANDS` is a small dispatch dict; `main(argv)` just looks up the handler and calls it.
  - `--choices=sorted(ALGORITHMS)` on `--algo` means typos surface in argparse's own usage text with the full valid list.
  - `--seed` is on the top-level parser so it controls both `split_ratings(random_state=...)` and stochastic algorithms (`SVD(random_state=...)`).
- **Entry point** — `[project.scripts] recsys = "recommender_systems.cli:main"` so the script is on `$PATH` after `pip install`.

## Output shape

`recommend` prints one item per line, prefixed with rank:

```
1	item_a
2	item_b
3	item_c
```

`evaluate` prints aligned metric rows:

```
precision@10   0.3188
recall@10      0.2010
MAP@10         0.2486
NDCG@10        0.3786
```

Unknown user → exit 1 with a message on stderr.
Unknown algorithm → argparse exits with usage text.

## Tests (7 new, 74 total)

Tests monkeypatch `load_movielens_100k` with a tiny synthetic frame so the CLI stays offline. They cover: `list-algos`, successful `recommend`, unknown-user nonzero-exit path, `evaluate` metric layout, invalid-algo argparse exit, missing-subcommand exit, and that `--seed` propagates correctly into `SVD(random_state=...)`.

## Local checks

```
ruff check src tests          # clean
ruff format --check src tests # clean
mypy                          # Success: no issues found in 10 source files
pytest                        # 74 passed
recsys list-algos             # works (entry point verified)
```

Closes #21