### PR TITLE
chore: stop running SVD at import time in model_based_collaborative_filter

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,6 @@ Worked examples, benchmarks across algorithms, and a published docs site.
 
 ## Known issues (carried over from the original code)
 
-- `model_based_collaborative_filter.py` executes at import time instead of inside a guard.
 - `get_recommended_items` has an inconsistent signature across modules.
 - The README has duplicated and mismatched algorithm descriptions.
 - No input validation and no tests on any existing module.

--- a/model_based_collaborative_filter.py
+++ b/model_based_collaborative_filter.py
@@ -1,46 +1,27 @@
+"""Legacy SVD-from-CSV demo script.
+
+Kept for historical continuity with the project's early commits. For new code use
+``recommender_systems.svd.SVD`` (same algorithm, on the unified ``Recommender``
+interface). The body of this file was previously executed at import time, which
+crashed with ``FileNotFoundError`` whenever the module was imported without the
+expected CSV present — now everything runs only via the ``__main__`` guard.
+"""
+
 import pandas as pd
 from sklearn.decomposition import TruncatedSVD
 from sklearn.preprocessing import Normalizer
 
-# Import the data
-df = pd.read_csv('user-item-data.csv')
 
-# Create a pivot table of the data
-df_pivot = df.pivot_table(index='user_id', columns='item_id', values='rating')
+def get_recommended_items(user, ratings_path="user-item-data.csv", N=10):
+    """Top-``N`` item ids for ``user``, trained from a CSV of (user_id, item_id, rating)."""
+    df = pd.read_csv(ratings_path)
+    df_pivot = df.pivot_table(index="user_id", columns="item_id", values="rating").fillna(0)
+    svd = TruncatedSVD(n_components=10, random_state=42)
+    normalized = Normalizer().fit_transform(svd.fit_transform(df_pivot.values))
+    user_row = normalized[user - 1, :]
+    scores = normalized.dot(user_row)
+    return df_pivot.columns[scores.argsort()[::-1][:N]]
 
-# Replace missing values with 0
-df_pivot.fillna(0, inplace=True)
 
-# Convert the pivot table to a matrix
-X = df_pivot.values
-
-# Create a TruncatedSVD model and fit it to the data
-svd = TruncatedSVD(n_components=10, random_state=42)
-X_transformed = svd.fit_transform(X)
-
-# Normalize the data
-normalizer = Normalizer()
-X_normalized = normalizer.fit_transform(X_transformed)
-
-# Create a function that returns the top N recommended items for a given user
-def get_recommended_items(user, N=10):
-    # Get the user's row from the matrix
-    user_row = X_normalized[user-1, :]
-    
-    # Calculate the dot product between the user's row and each item's column
-    scores = X_normalized.dot(user_row)
-    
-    # Sort the scores in descending order
-    sorted_scores = scores.argsort()[::-1]
-    
-    # Get the top N items with the highest scores
-    top_items = sorted_scores[:N]
-    
-    # Return the item IDs
-    return df_pivot.columns[top_items]
-
-# Get the recommendations for the user
-recommendations = get_recommended_items(1)
-
-# Print the recommendations
-print(recommendations)
+if __name__ == "__main__":
+    print(get_recommended_items(1))

--- a/tests/test_legacy_scripts.py
+++ b/tests/test_legacy_scripts.py
@@ -1,0 +1,26 @@
+"""Regression tests for the legacy top-level scripts kept at the repo root.
+
+These files predate the package layout and aren't imported by anything else,
+but they should still load cleanly so future contributors don't trip over
+import-time side effects (see #3).
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _import_legacy(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_model_based_collaborative_filter_imports_without_side_effects():
+    # Previously this module read a CSV and ran SVD at import time, which
+    # crashed whenever the file wasn't present in the cwd.
+    module = _import_legacy("model_based_collaborative_filter")
+    assert callable(module.get_recommended_items)


### PR DESCRIPTION
Smallest of the ROADMAP's "known issues" carried over from the original code.

The legacy script used to read `user-item-data.csv` and run a `TruncatedSVD` at module scope, which raised `FileNotFoundError` on any import — including a plain `python -c "import model_based_collaborative_filter"`. Everything beyond the function definition now sits under `if __name__ == "__main__":`, and `get_recommended_items` takes the CSV path as an argument so it's self-contained when called.

`tests/test_legacy_scripts.py` is new: a tiny regression test that loads the file via `importlib` and asserts the function is callable. It catches any future drift back into module-scope side effects, without needing the script's data file to exist.

ROADMAP's "known issues" bullet for this is removed.

## Local checks

```
ruff check src tests          # clean
ruff format --check src tests # clean
mypy                          # Success: no issues found in 9 source files
pytest                        # 68 passed
```

Closes #3