### PR TITLE
Add save/load for fitted recommenders

### DIFF
--- a/src/recommender_systems/persistence.py
+++ b/src/recommender_systems/persistence.py
@@ -1,0 +1,26 @@
+"""Save and load fitted recommenders."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+from recommender_systems.base import Recommender
+
+__all__ = ["load", "save"]
+
+
+def save(model: Recommender, path: str | Path) -> None:
+    """Persist a fitted recommender to ``path`` using pickle."""
+    Path(path).write_bytes(pickle.dumps(model))
+
+
+def load(path: str | Path) -> Recommender:
+    """Load a recommender previously saved with :func:`save`.
+
+    Only load files you trust: unpickling executes arbitrary code.
+    """
+    obj = pickle.loads(Path(path).read_bytes())
+    if not isinstance(obj, Recommender):
+        raise TypeError(f"{path} does not contain a Recommender")
+    return obj

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,28 @@
+import pickle
+
+import pandas as pd
+import pytest
+
+from recommender_systems.baselines import MostPopular
+from recommender_systems.persistence import load, save
+
+
+def test_round_trip_preserves_recommendations(tmp_path):
+    ratings = pd.DataFrame(
+        {"user_id": [1, 1, 2, 2], "item_id": ["a", "b", "a", "c"], "rating": [5, 4, 3, 2]}
+    )
+    model = MostPopular().fit(ratings)
+    path = tmp_path / "model.pkl"
+
+    save(model, path)
+    loaded = load(path)
+
+    assert loaded.recommend(2, n=5) == model.recommend(2, n=5)
+
+
+def test_load_rejects_non_recommender(tmp_path):
+    path = tmp_path / "bad.pkl"
+    path.write_bytes(pickle.dumps({"not": "a model"}))
+
+    with pytest.raises(TypeError, match="Recommender"):
+        load(path)


### PR DESCRIPTION
`persistence.save(model, path)` / `load(path)` pickle a fitted recommender and restore it, with a type check on load and a "only load files you trust" caveat. Train once, reuse from the CLI or an app.

Tested: round-trip preserves recommendations; loading a non-recommender raises `TypeError`.

Closes #56