### PR TITLE
docs: list BPR and the text_features builder in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ recsys evaluate  --algo svd
 | `recommender_systems.neighborhood`  | `UserKNN`, `ItemKNN` | Cosine-similarity neighborhood CF                    |
 | `recommender_systems.svd`           | `SVD`                | Truncated SVD on the user-item matrix                |
 | `recommender_systems.content`       | `ContentBased`       | Item-feature similarity (TF-IDF, tags, embeddings)   |
+| `recommender_systems.bpr`           | `BPR`                | Bayesian Personalized Ranking for implicit feedback  |
+
+`recommender_systems.features.text_features` builds TF-IDF / count / binary
+item-by-term matrices from per-item text, ready to pass to `ContentBased`.
 
 Evaluation metrics — `precision@k`, `recall@k`, `MAP@k`, `NDCG@k`, plus the
 beyond-accuracy set (intra-list diversity, novelty, catalog coverage,


### PR DESCRIPTION
Trivial follow-up to #61. Both #58 (BPR) and #60 (text features) landed minutes after the README rewrite was open, so the algorithms table didn't list them. This adds the BPR row plus a one-liner pointing at `text_features` as the feature-builder counterpart to `ContentBased`. Four added lines, no other changes.