### PR TITLE
Add HybridRecommender (weighted reciprocal-rank fusion)

### DIFF
--- a/src/recommender_systems/hybrid.py
+++ b/src/recommender_systems/hybrid.py
@@ -1,0 +1,63 @@
+"""Combine several recommenders by weighted reciprocal-rank fusion."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Sequence
+
+import pandas as pd
+
+from recommender_systems.base import Recommender
+
+__all__ = ["HybridRecommender"]
+
+
+class HybridRecommender(Recommender):
+    """Blend several recommenders via weighted reciprocal-rank fusion.
+
+    Each component produces its own ranked list; an item scores
+    ``sum_r weight_r / (rank_constant + rank_r)``, so items ranked highly by several
+    weighted components rise to the top. Because the components already exclude items
+    the user has rated, the fused list does too. Rank fusion needs only the public
+    ``recommend`` output, so any recommender can be combined.
+
+    Parameters
+    ----------
+    recommenders
+        Component recommenders to combine.
+    weights
+        Per-component weights; defaults to equal weighting.
+    rank_constant
+        Dampens the contribution of top ranks (the standard RRF constant).
+    pool
+        How many items to pull from each component before fusing.
+    """
+
+    def __init__(
+        self,
+        recommenders: Sequence[Recommender],
+        weights: Sequence[float] | None = None,
+        *,
+        rank_constant: int = 60,
+        pool: int = 100,
+    ) -> None:
+        if not recommenders:
+            raise ValueError("need at least one recommender")
+        if weights is not None and len(weights) != len(recommenders):
+            raise ValueError("weights must match the number of recommenders")
+        self.recommenders = list(recommenders)
+        self.weights = list(weights) if weights is not None else [1.0] * len(recommenders)
+        self.rank_constant = rank_constant
+        self.pool = pool
+
+    def fit(self, ratings: pd.DataFrame) -> HybridRecommender:
+        for recommender in self.recommenders:
+            recommender.fit(ratings)
+        return self
+
+    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
+        scores: dict[Hashable, float] = {}
+        for recommender, weight in zip(self.recommenders, self.weights, strict=True):
+            for rank, item in enumerate(recommender.recommend(user_id, n=self.pool), start=1):
+                scores[item] = scores.get(item, 0.0) + weight / (self.rank_constant + rank)
+        ranked = sorted(scores, key=lambda item: scores[item], reverse=True)
+        return ranked[:n]

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from recommender_systems.base import Recommender
+from recommender_systems.hybrid import HybridRecommender
+
+
+class _Fixed(Recommender):
+    """A recommender that always returns a fixed ranked list, for testing fusion."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def fit(self, ratings):
+        return self
+
+    def recommend(self, user_id, n=10):
+        return self._items[:n]
+
+
+def test_hybrid_implements_interface():
+    assert issubclass(HybridRecommender, Recommender)
+
+
+def test_fusion_lifts_items_ranked_by_multiple_components():
+    # "y" is the only item both components recommend, so fusion should rank it first.
+    a = _Fixed(["x", "y"])
+    b = _Fixed(["y", "z"])
+    model = HybridRecommender([a, b]).fit(pd.DataFrame())
+    assert model.recommend(1, n=1) == ["y"]
+
+
+def test_weights_shift_the_ranking():
+    a = _Fixed(["x"])
+    b = _Fixed(["z"])
+    # Weighting the second component far higher puts its pick on top.
+    model = HybridRecommender([a, b], weights=[1.0, 10.0]).fit(pd.DataFrame())
+    assert model.recommend(1, n=1) == ["z"]
+
+
+def test_requires_at_least_one_recommender():
+    with pytest.raises(ValueError, match="at least one"):
+        HybridRecommender([])
+
+
+def test_weights_must_match_recommenders():
+    with pytest.raises(ValueError, match="weights must match"):
+        HybridRecommender([_Fixed(["a"])], weights=[1.0, 2.0])


### PR DESCRIPTION
Delivers the **hybrid** recommender from #12. Uses **weighted reciprocal-rank fusion** over each component's `recommend()` output, so it composes with any recommender (kNN, SVD, ContentBased, baselines) without needing private scores. Components already drop seen items, so the fused list does too.

Tested: fusion lifts items ranked by multiple components, weights shift the ranking, and the validation guards (empty list, mismatched weights).

Note on #12: this covers the hybrid piece. The remaining demographic / context-aware migrations are niche given the current algorithm coverage — I'd suggest tracking them as a separate low-priority item (or dropping them) rather than bundling. Not closing #12 here.