### PR TITLE
Export recommenders from the package root

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -1,8 +1,26 @@
 """Recommender Systems: classic and modern recommendation algorithms."""
 
 from recommender_systems.base import Recommender
+from recommender_systems.baselines import MeanRating, MostPopular
+from recommender_systems.bpr import BPR
+from recommender_systems.content import ContentBased
 from recommender_systems.data import build_user_item_matrix, split_ratings
+from recommender_systems.hybrid import HybridRecommender
+from recommender_systems.neighborhood import ItemKNN, UserKNN
+from recommender_systems.svd import SVD
 
 __version__ = "0.1.0"
 
-__all__ = ["Recommender", "build_user_item_matrix", "split_ratings"]
+__all__ = [
+    "BPR",
+    "SVD",
+    "ContentBased",
+    "HybridRecommender",
+    "ItemKNN",
+    "MeanRating",
+    "MostPopular",
+    "Recommender",
+    "UserKNN",
+    "build_user_item_matrix",
+    "split_ratings",
+]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,26 @@
+import recommender_systems
+from recommender_systems import Recommender
+
+EXPECTED_RECOMMENDERS = [
+    "BPR",
+    "ContentBased",
+    "HybridRecommender",
+    "ItemKNN",
+    "MeanRating",
+    "MostPopular",
+    "SVD",
+    "UserKNN",
+]
+
+
+def test_recommenders_are_importable_from_the_package_root():
+    for name in EXPECTED_RECOMMENDERS:
+        obj = getattr(recommender_systems, name)
+        assert issubclass(obj, Recommender), name
+        assert name in recommender_systems.__all__
+
+
+def test_core_utilities_are_exported():
+    for name in ("build_user_item_matrix", "split_ratings"):
+        assert callable(getattr(recommender_systems, name))
+        assert name in recommender_systems.__all__


### PR DESCRIPTION
The consolidation pass deferred during parallel development. Every recommender — `MostPopular`, `MeanRating`, `UserKNN`, `ItemKNN`, `SVD`, `ContentBased`, `BPR`, `HybridRecommender` — plus `Recommender`, `build_user_item_matrix`, and `split_ratings` is now importable from the package root:

```python
from recommender_systems import SVD, ItemKNN, HybridRecommender
```

Submodule imports still work. A new test locks the public surface (each export is a `Recommender` subclass and present in `__all__`).

Closes #64