### PR TITLE
Add densest_subset for dense algorithms on large datasets

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -4,7 +4,7 @@ from recommender_systems.base import Recommender
 from recommender_systems.baselines import MeanRating, MostPopular
 from recommender_systems.bpr import BPR
 from recommender_systems.content import ContentBased
-from recommender_systems.data import build_user_item_matrix, split_ratings
+from recommender_systems.data import build_user_item_matrix, densest_subset, split_ratings
 from recommender_systems.hybrid import HybridRecommender
 from recommender_systems.neighborhood import ItemKNN, UserKNN
 from recommender_systems.svd import SVD
@@ -22,5 +22,6 @@ __all__ = [
     "Recommender",
     "UserKNN",
     "build_user_item_matrix",
+    "densest_subset",
     "split_ratings",
 ]

--- a/src/recommender_systems/data.py
+++ b/src/recommender_systems/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-__all__ = ["build_user_item_matrix", "split_ratings"]
+__all__ = ["build_user_item_matrix", "densest_subset", "split_ratings"]
 
 
 def build_user_item_matrix(
@@ -77,3 +77,28 @@ def split_ratings(
     train = ratings.iloc[train_rows].reset_index(drop=True)
     test = ratings.iloc[test_rows].reset_index(drop=True)
     return train, test
+
+
+def densest_subset(
+    ratings: pd.DataFrame,
+    *,
+    n_users: int = 1000,
+    n_items: int = 1000,
+    user_col: str = "user_id",
+    item_col: str = "item_id",
+) -> pd.DataFrame:
+    """Restrict ratings to the most active users and most popular items.
+
+    Lets dense-matrix algorithms run on large datasets (e.g. goodbooks-10k) without
+    materializing a full user-by-item matrix. Keeps the ``n_users`` users with the most
+    interactions and the ``n_items`` most-interacted items, then the rows in both.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The filtered ratings.
+    """
+    top_users = ratings[user_col].value_counts().head(n_users).index
+    top_items = ratings[item_col].value_counts().head(n_items).index
+    keep = ratings[user_col].isin(top_users) & ratings[item_col].isin(top_items)
+    return ratings[keep].reset_index(drop=True)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from recommender_systems import build_user_item_matrix, split_ratings
+from recommender_systems import build_user_item_matrix, densest_subset, split_ratings
 
 
 @pytest.fixture
@@ -56,3 +56,17 @@ def test_split_invalid_size_raises(ratings):
     for bad in (0.0, 1.0, -0.1, 1.5):
         with pytest.raises(ValueError, match="test_size"):
             split_ratings(ratings, test_size=bad)
+
+
+def test_densest_subset_keeps_top_users_and_items():
+    rows = []
+    # users 1 and 2 are active; user 3 rates once. items a, b are popular; c is rare.
+    for _ in range(3):
+        rows += [(1, "a"), (2, "b")]
+    rows += [(1, "b"), (2, "a"), (3, "c")]
+    ratings = pd.DataFrame(rows, columns=["user_id", "item_id"]).assign(rating=1)
+
+    subset = densest_subset(ratings, n_users=2, n_items=2)
+
+    assert set(subset["user_id"]) == {1, 2}
+    assert set(subset["item_id"]) == {"a", "b"}


### PR DESCRIPTION
The book benchmark (#43) and content recommender (#44) can't run on full goodbooks-10k: our recommenders build a *dense* user-item matrix, and ~53k users × 10k items ≈ 530M cells (~4 GB) would OOM.

`densest_subset(ratings, n_users=1000, n_items=1000)` keeps the most active users and most popular items so dense algorithms run on a tractable slice. Exported from the package root; tested.

The book showcase issues should call this before fitting on goodbooks-10k. (Full scipy-sparse support across the recommenders remains a possible larger future enhancement.)

Closes #66