### PR TITLE
Add holdout_per_user split for fair top-N evaluation

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -4,7 +4,12 @@ from recommender_systems.base import Recommender
 from recommender_systems.baselines import MeanRating, MostPopular
 from recommender_systems.bpr import BPR
 from recommender_systems.content import ContentBased
-from recommender_systems.data import build_user_item_matrix, densest_subset, split_ratings
+from recommender_systems.data import (
+    build_user_item_matrix,
+    densest_subset,
+    holdout_per_user,
+    split_ratings,
+)
 from recommender_systems.hybrid import HybridRecommender
 from recommender_systems.neighborhood import ItemKNN, UserKNN
 from recommender_systems.svd import SVD
@@ -23,5 +28,6 @@ __all__ = [
     "UserKNN",
     "build_user_item_matrix",
     "densest_subset",
+    "holdout_per_user",
     "split_ratings",
 ]

--- a/src/recommender_systems/data.py
+++ b/src/recommender_systems/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-__all__ = ["build_user_item_matrix", "densest_subset", "split_ratings"]
+__all__ = ["build_user_item_matrix", "densest_subset", "holdout_per_user", "split_ratings"]
 
 
 def build_user_item_matrix(
@@ -102,3 +102,36 @@ def densest_subset(
     top_items = ratings[item_col].value_counts().head(n_items).index
     keep = ratings[user_col].isin(top_users) & ratings[item_col].isin(top_items)
     return ratings[keep].reset_index(drop=True)
+
+
+def holdout_per_user(
+    ratings: pd.DataFrame,
+    *,
+    test_size: float = 0.2,
+    random_state: int | None = None,
+    user_col: str = "user_id",
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Hold out a fraction of each user's interactions for testing.
+
+    Unlike :func:`split_ratings` (a global row split), this guarantees every user with at
+    least two interactions keeps training history — the standard protocol for top-N
+    recommender evaluation, so no user is left cold in the test set. Users with a single
+    interaction stay entirely in train.
+
+    Returns
+    -------
+    tuple of pandas.DataFrame
+        ``(train, test)``.
+    """
+    if not 0.0 < test_size < 1.0:
+        raise ValueError(f"test_size must be in (0, 1), got {test_size}")
+    rng = np.random.default_rng(random_state)
+    test_mask = np.zeros(len(ratings), dtype=bool)
+    for positions in ratings.groupby(user_col).indices.values():
+        if len(positions) < 2:
+            continue
+        n_test = min(max(1, round(len(positions) * test_size)), len(positions) - 1)
+        test_mask[rng.choice(positions, size=n_test, replace=False)] = True
+    train = ratings[~test_mask].reset_index(drop=True)
+    test = ratings[test_mask].reset_index(drop=True)
+    return train, test

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from recommender_systems import build_user_item_matrix, densest_subset, split_ratings
+from recommender_systems import (
+    build_user_item_matrix,
+    densest_subset,
+    holdout_per_user,
+    split_ratings,
+)
 
 
 @pytest.fixture
@@ -70,3 +75,27 @@ def test_densest_subset_keeps_top_users_and_items():
 
     assert set(subset["user_id"]) == {1, 2}
     assert set(subset["item_id"]) == {"a", "b"}
+
+
+def test_holdout_per_user_keeps_every_user_in_train():
+    rows = [(u, i) for u in range(5) for i in range(10)]  # 5 users x 10 items
+    rows.append((99, 0))  # a single-interaction user
+    ratings = pd.DataFrame(rows, columns=["user_id", "item_id"]).assign(rating=1)
+
+    train, test = holdout_per_user(ratings, test_size=0.2, random_state=0)
+
+    # every user appears in train (no cold users); the singleton stays out of test
+    assert set(train["user_id"]) == set(ratings["user_id"])
+    assert 99 not in set(test["user_id"])
+    # each multi-item user has ~2 of 10 held out
+    assert (test["user_id"] == 0).sum() == 2
+    assert len(train) + len(test) == len(ratings)
+
+
+def test_holdout_per_user_is_reproducible():
+    ratings = pd.DataFrame(
+        [(u, i) for u in range(4) for i in range(8)], columns=["user_id", "item_id"]
+    ).assign(rating=1)
+    a = holdout_per_user(ratings, random_state=7)
+    b = holdout_per_user(ratings, random_state=7)
+    pd.testing.assert_frame_equal(a[1], b[1])


### PR DESCRIPTION
Part of #69. Adds the per-user holdout primitive: `holdout_per_user(ratings, test_size=, random_state=)` holds out a fraction of *each user's* interactions, so every user with ≥2 interactions keeps training history (no cold users in test), with singletons left in train. This is the standard top-N evaluation protocol, unlike `split_ratings`'s global row split.

Exported from the package root; tested (every user in train, singleton excluded from test, reproducible).

**Remaining for #69:** wiring this into `_harness.run_benchmark` and regenerating the committed benchmark results — best done as a follow-up with an actual benchmark re-run, so I've left #69 open and scoped this PR to the primitive.