### PR TITLE
Expose BPR in the recsys CLI; document the [neural] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ pip install -e .
 
 Optional extras:
 
+- `[neural]` — PyTorch for the two-tower neural CF (`TwoTowerCF`)
 - `[embeddings]` — gensim for word-embedding features
-- `[benchmarks]` — matplotlib + tabulate for `scripts/benchmark.py`
+- `[benchmarks]` — matplotlib + tabulate for the benchmark scripts
 - `[docs]` — mkdocs-material for building the docs site
 - `[dev]` — ruff, mypy, pytest, pytest-cov
 

--- a/src/recommender_systems/cli.py
+++ b/src/recommender_systems/cli.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Sequence
 
 from recommender_systems import Recommender, split_ratings
 from recommender_systems.baselines import MeanRating, MostPopular
+from recommender_systems.bpr import BPR
 from recommender_systems.datasets import load_movielens_100k
 from recommender_systems.metrics import (
     mean_average_precision,
@@ -33,6 +34,7 @@ ALGORITHMS: dict[str, Callable[..., Recommender]] = {
     "item-knn": ItemKNN,
     "user-knn": UserKNN,
     "svd": SVD,
+    "bpr": BPR,
 }
 
 
@@ -71,7 +73,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _instantiate(name: str, seed: int) -> Recommender:
     factory = ALGORITHMS[name]
-    if name == "svd":
+    if name in {"bpr", "svd"}:
         return factory(random_state=seed)
     return factory()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,3 +80,12 @@ def test_seed_propagates_to_svd(monkeypatch, fake_ratings):
     code = cli.main(["--seed", "42", "recommend", "--algo", "svd", "--user", "1", "--n", "1"])
     assert code == 0
     assert seen == {"random_state": 42}
+
+
+def test_bpr_is_registered_and_seeded():
+    from recommender_systems.bpr import BPR
+
+    assert "bpr" in cli.ALGORITHMS
+    model = cli._instantiate("bpr", seed=7)
+    assert isinstance(model, BPR)
+    assert model.random_state == 7


### PR DESCRIPTION
Two completeness fixes I found while reviewing:

- **`recsys` CLI was missing BPR.** It's a ratings-only recommender like the others, but wasn't in the `ALGORITHMS` registry — so `recsys recommend --algo bpr` failed. Added it (with `random_state` handling, like SVD) + a test. `list-algos` now shows all six ratings-based algorithms.
- **README didn't list the `[neural]` extra.** `TwoTowerCF` requires `pip install '...[neural]'` (per the Algorithms table), but the install section's extras list omitted it. Added it; also fixed the `[benchmarks]` description (the scripts run via `python -m scripts.benchmark`).

Gate green (mypy + ruff + 101 tests).