### PR TITLE
feat: explainable recommendations on ContentBased

### DIFF
--- a/src/recommender_systems/content.py
+++ b/src/recommender_systems/content.py
@@ -36,7 +36,10 @@ class ContentBased(_MatrixBackedRecommender):
     def __init__(self, item_features: pd.DataFrame) -> None:
         super().__init__()
         self._item_features = item_features
-        self._predicted = np.empty((0, 0))
+        self._predicted: np.ndarray = np.empty((0, 0))
+        self._aligned_features: np.ndarray = np.empty((0, 0))
+        self._profiles: np.ndarray = np.empty((0, 0))
+        self._feature_names: list[str] = []
 
     def fit(self, ratings: pd.DataFrame) -> ContentBased:
         rated_matrix = build_user_item_matrix(ratings, fill_value=0.0)
@@ -45,12 +48,47 @@ class ContentBased(_MatrixBackedRecommender):
         # union of rated and featured items.
         item_space = rated_matrix.columns.union(self._item_features.index)
         self._matrix = rated_matrix.reindex(columns=item_space, fill_value=0.0)
-        features = self._item_features.reindex(self._matrix.columns).fillna(0.0).to_numpy()
+        aligned = self._item_features.reindex(self._matrix.columns).fillna(0.0)
+        self._aligned_features = aligned.to_numpy()
+        self._feature_names = list(aligned.columns)
         weights = self._matrix.to_numpy()
         row_sums = weights.sum(axis=1, keepdims=True)
-        profiles = np.divide(weights @ features, np.where(row_sums == 0, 1.0, row_sums))
-        self._predicted = np.asarray(cosine_similarity(profiles, features))
+        self._profiles = np.divide(
+            weights @ self._aligned_features, np.where(row_sums == 0, 1.0, row_sums)
+        )
+        self._predicted = np.asarray(cosine_similarity(self._profiles, self._aligned_features))
         return self
 
     def _user_scores(self, user_id: Hashable) -> np.ndarray:
         return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])
+
+    def explain(self, user_id: Hashable, item_id: Hashable, top_features: int = 3) -> str:
+        """Return the top features driving ``item_id``'s score for ``user_id``.
+
+        For each feature, the contribution to the user-item similarity is the
+        product of the user's profile weight and the item's feature weight.
+        The top non-zero features are returned as a comma-separated string —
+        e.g. ``"fantasy, magic, epic"`` for a fantasy-genre recommendation.
+        Returns ``""`` if the user or item is unknown or the user has no profile.
+        """
+        if user_id not in self._matrix.index or item_id not in self._matrix.columns:
+            return ""
+        u_idx = self._matrix.index.get_loc(user_id)
+        i_idx = self._matrix.columns.get_loc(item_id)
+        contributions = self._profiles[u_idx] * self._aligned_features[i_idx]
+        if not contributions.any():
+            return ""
+        top_idx = np.argsort(-contributions)[:top_features]
+        return ", ".join(self._feature_names[i] for i in top_idx if contributions[i] > 0)
+
+    def recommend_with_reasons(
+        self, user_id: Hashable, n: int = 10, top_features: int = 3
+    ) -> list[tuple[Hashable, str]]:
+        """Top-``n`` recommendations for ``user_id`` paired with their explanations.
+
+        Each entry is ``(item_id, reason)`` where ``reason`` is the output of
+        :meth:`explain` for that item — empty string if no features contribute.
+        """
+        return [
+            (item, self.explain(user_id, item, top_features)) for item in self.recommend(user_id, n)
+        ]

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -60,3 +60,28 @@ def test_handles_items_missing_from_features():
     model = ContentBased(partial_features).fit(ratings)
     # User 1 still prefers d (the action item that's in the feature table).
     assert model.recommend(1, n=1) == ["d"]
+
+
+def test_explain_returns_top_shared_features():
+    # User 1 rated "a" (pure action). Recommending "d" (also pure action)
+    # should attribute the score to the "action" feature.
+    model = ContentBased(sample_item_features()).fit(sample_ratings())
+    reason = model.explain(user_id=1, item_id="d")
+    assert reason == "action"
+
+
+def test_explain_unknown_user_or_item_returns_empty():
+    model = ContentBased(sample_item_features()).fit(sample_ratings())
+    assert model.explain(user_id=999, item_id="d") == ""
+    assert model.explain(user_id=1, item_id="ghost") == ""
+
+
+def test_recommend_with_reasons_pairs_each_item_with_explanation():
+    model = ContentBased(sample_item_features()).fit(sample_ratings())
+    results = model.recommend_with_reasons(user_id=1, n=2)
+    assert len(results) == 2
+    items, reasons = zip(*results, strict=True)
+    # Same ranking as plain recommend.
+    assert list(items) == model.recommend(1, n=2)
+    # The first (best-matching) item gets a non-empty reason.
+    assert reasons[0] != ""


### PR DESCRIPTION
Closes #45. Adds two methods on `ContentBased` that turn the cosine-similarity score into a human-readable reason.

## API

```python
model = ContentBased(item_features=tag_tfidf).fit(ratings)

reason = model.explain(user_id=42, item_id="some_book")
# "fantasy, magic, epic"

results = model.recommend_with_reasons(user_id=42, n=10)
# [("book_a", "fantasy, magic, epic"),
#  ("book_b", "mystery, noir"),
#  ...]
```

The reason is built from the per-feature contribution to the similarity score: `user_profile_weight * item_feature_weight`. Top non-zero features ranked by contribution become the explanation.

## Implementation

`fit` now also stores the aligned feature matrix, the user profile matrix, and the feature names, so `explain` is a fast lookup rather than a recompute. Memory cost is `O(n_users * n_features)`, which is small relative to the existing `n_users * n_items` prediction matrix already cached.

## Tests (3 new, 110 total)

- Worked example: user rates a pure-action item, recommends another pure-action item — explanation is exactly `"action"`.
- Unknown user or unknown item → empty string (no exception).
- `recommend_with_reasons` returns the same ranking as `recommend`, with non-empty reasons for the top-matching items.

## Local checks

```
ruff check src tests scripts            # clean
ruff format --check src tests scripts   # clean
mypy                                    # Success: no issues found in 16 source files
pytest                                  # 110 passed
```

Closes #45