### PR TITLE
Add sparse user-item matrix builder

### DIFF
--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -5,6 +5,7 @@ from recommender_systems.baselines import MeanRating, MostPopular
 from recommender_systems.bpr import BPR
 from recommender_systems.content import ContentBased
 from recommender_systems.data import (
+    build_sparse_user_item_matrix,
     build_user_item_matrix,
     densest_subset,
     holdout_per_user,
@@ -26,6 +27,7 @@ __all__ = [
     "MostPopular",
     "Recommender",
     "UserKNN",
+    "build_sparse_user_item_matrix",
     "build_user_item_matrix",
     "densest_subset",
     "holdout_per_user",

--- a/src/recommender_systems/data.py
+++ b/src/recommender_systems/data.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
-__all__ = ["build_user_item_matrix", "densest_subset", "holdout_per_user", "split_ratings"]
+__all__ = [
+    "build_sparse_user_item_matrix",
+    "build_user_item_matrix",
+    "densest_subset",
+    "holdout_per_user",
+    "split_ratings",
+]
 
 
 def build_user_item_matrix(
@@ -135,3 +142,35 @@ def holdout_per_user(
     train = ratings[~test_mask].reset_index(drop=True)
     test = ratings[test_mask].reset_index(drop=True)
     return train, test
+
+
+def build_sparse_user_item_matrix(
+    ratings: pd.DataFrame,
+    *,
+    user_col: str = "user_id",
+    item_col: str = "item_id",
+    rating_col: str = "rating",
+) -> tuple[sparse.csr_matrix, pd.Index, pd.Index]:
+    """Build a sparse user-item matrix plus its id-to-position index maps.
+
+    Scales to corpora where the dense :func:`build_user_item_matrix` would not fit in
+    memory (e.g. full goodbooks-10k). Duplicate (user, item) pairs are averaged, matching
+    the dense builder.
+
+    Returns
+    -------
+    tuple
+        ``(matrix, users, items)`` — a CSR matrix, an index mapping row to user id, and an
+        index mapping column to item id (use ``.get_loc(id)`` for the reverse direction).
+    """
+    missing = {user_col, item_col, rating_col} - set(ratings.columns)
+    if missing:
+        raise ValueError(f"ratings is missing required columns: {sorted(missing)}")
+    agg = ratings.groupby([user_col, item_col], sort=True)[rating_col].mean().reset_index()
+    user_codes, users = pd.factorize(agg[user_col], sort=True)
+    item_codes, items = pd.factorize(agg[item_col], sort=True)
+    matrix = sparse.csr_matrix(
+        (agg[rating_col].to_numpy(), (user_codes, item_codes)),
+        shape=(len(users), len(items)),
+    )
+    return matrix, pd.Index(users), pd.Index(items)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
+from scipy import sparse
 
 from recommender_systems import (
+    build_sparse_user_item_matrix,
     build_user_item_matrix,
     densest_subset,
     holdout_per_user,
@@ -99,3 +101,24 @@ def test_holdout_per_user_is_reproducible():
     a = holdout_per_user(ratings, random_state=7)
     b = holdout_per_user(ratings, random_state=7)
     pd.testing.assert_frame_equal(a[1], b[1])
+
+
+def test_build_sparse_user_item_matrix_shape_values_and_maps():
+    ratings = pd.DataFrame(
+        {"user_id": [1, 1, 2], "item_id": ["a", "b", "a"], "rating": [5.0, 3.0, 4.0]}
+    )
+    matrix, users, items = build_sparse_user_item_matrix(ratings)
+
+    assert sparse.issparse(matrix)
+    assert matrix.shape == (len(users), len(items)) == (2, 2)
+    assert list(users) == [1, 2]
+    assert list(items) == ["a", "b"]
+    assert matrix[users.get_loc(1), items.get_loc("b")] == 3.0
+    assert matrix[users.get_loc(2), items.get_loc("a")] == 4.0
+    assert matrix[users.get_loc(2), items.get_loc("b")] == 0.0
+
+
+def test_build_sparse_averages_duplicate_pairs():
+    ratings = pd.DataFrame({"user_id": [1, 1], "item_id": ["a", "a"], "rating": [2.0, 4.0]})
+    matrix, _users, _items = build_sparse_user_item_matrix(ratings)
+    assert matrix[0, 0] == 3.0


### PR DESCRIPTION
Step 1 of #77 (scale beyond the dense ~4 GB ceiling).

`build_sparse_user_item_matrix(ratings)` → `(csr_matrix, users, items)`: a SciPy CSR matrix plus an index mapping row→user id and column→item id. Duplicate (user, item) pairs are averaged, matching the dense builder. Exported and tested (shape, values, id maps, duplicate averaging).

Next increment wires it into `UserKNN`/`ItemKNN`/`SVD` (both accept sparse input) so the goodbooks benchmark can run the full corpus rather than a 2500-user subsample. Left #77 open for that.