### PR TITLE
feat: ALS (Alternating Least Squares) for implicit feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ recsys evaluate  --algo svd
 | `recommender_systems.svd`           | `SVD`                | Truncated SVD on the user-item matrix                |
 | `recommender_systems.content`       | `ContentBased`       | Item-feature similarity (TF-IDF, tags, embeddings)   |
 | `recommender_systems.bpr`           | `BPR`                | Bayesian Personalized Ranking (numpy SGD)            |
+| `recommender_systems.als`           | `ALS`                | Alternating Least Squares (Hu/Koren/Volinsky 2008)   |
 | `recommender_systems.neural`        | `TwoTowerCF`         | Two-tower neural CF (PyTorch; requires `[neural]`)   |
 
 `recommender_systems.features.text_features` builds TF-IDF / count / binary

--- a/src/recommender_systems/__init__.py
+++ b/src/recommender_systems/__init__.py
@@ -1,5 +1,6 @@
 """Recommender Systems: classic and modern recommendation algorithms."""
 
+from recommender_systems.als import ALS
 from recommender_systems.base import Recommender
 from recommender_systems.baselines import MeanRating, MostPopular
 from recommender_systems.bpr import BPR
@@ -17,6 +18,7 @@ from recommender_systems.svd import SVD
 __version__ = "0.1.0"
 
 __all__ = [
+    "ALS",
     "BPR",
     "SVD",
     "ContentBased",

--- a/src/recommender_systems/als.py
+++ b/src/recommender_systems/als.py
@@ -1,0 +1,97 @@
+"""Alternating Least Squares for implicit-feedback matrix factorization."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+import numpy as np
+import pandas as pd
+
+from recommender_systems.base import _MatrixBackedRecommender
+from recommender_systems.data import build_user_item_matrix
+
+__all__ = ["ALS"]
+
+
+class ALS(_MatrixBackedRecommender):
+    """Implicit-feedback matrix factorization via alternating least squares.
+
+    Follows Hu, Koren & Volinsky (2008): binary preferences ``p_ui = 1 if r_ui > 0``
+    with confidence ``c_ui = 1 + alpha * r_ui``, then alternate closed-form solves
+    for the user factors ``X`` and item factors ``Y`` of the regularized weighted
+    least-squares loss.
+
+    Same algorithm family as :class:`recommender_systems.bpr.BPR` but a different
+    optimization story — closed-form alternating solves instead of SGD on a sigmoid
+    margin — so it tends to converge in many fewer epochs.
+
+    Parameters
+    ----------
+    n_factors
+        Latent factor dimensionality.
+    epochs
+        Full passes over the (X, Y) update cycle.
+    regularization
+        L2 regularization strength applied to the factor solves.
+    alpha
+        Confidence scaling: a rating of ``r`` contributes weight ``1 + alpha * r``.
+        Higher ``alpha`` makes the model trust observed ratings more.
+    random_state
+        Seed for factor initialization.
+    """
+
+    def __init__(
+        self,
+        n_factors: int = 32,
+        epochs: int = 15,
+        regularization: float = 0.01,
+        alpha: float = 40.0,
+        random_state: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.n_factors = n_factors
+        self.epochs = epochs
+        self.regularization = regularization
+        self.alpha = alpha
+        self.random_state = random_state
+        self._predicted: np.ndarray = np.empty((0, 0))
+
+    def fit(self, ratings: pd.DataFrame) -> ALS:
+        self._matrix = build_user_item_matrix(ratings, fill_value=0.0)
+        ratings_mat = self._matrix.to_numpy()
+        preferences = (ratings_mat > 0).astype(np.float64)
+        confidence = 1.0 + self.alpha * ratings_mat
+        n_users, n_items = ratings_mat.shape
+
+        rng = np.random.default_rng(self.random_state)
+        user_factors = rng.normal(0.0, 0.01, size=(n_users, self.n_factors))
+        item_factors = rng.normal(0.0, 0.01, size=(n_items, self.n_factors))
+        reg_eye = self.regularization * np.eye(self.n_factors)
+
+        for _ in range(self.epochs):
+            user_factors = self._solve_side(item_factors, confidence, preferences, reg_eye)
+            item_factors = self._solve_side(user_factors, confidence.T, preferences.T, reg_eye)
+
+        self._predicted = np.asarray(user_factors @ item_factors.T)
+        return self
+
+    @staticmethod
+    def _solve_side(
+        other: np.ndarray, confidence: np.ndarray, preferences: np.ndarray, reg_eye: np.ndarray
+    ) -> np.ndarray:
+        """Closed-form solve for one factor matrix given the other side fixed.
+
+        Solving the side with rows ``u`` means: for each ``u`` find ``x_u`` minimizing
+        ``sum_i c_{u,i} (p_{u,i} - x_u . y_i)^2 + lambda ||x_u||^2``.
+        """
+        gram = other.T @ other  # (f, f)
+        target = np.empty((confidence.shape[0], other.shape[1]))
+        for row in range(confidence.shape[0]):
+            cu_minus_1 = confidence[row] - 1.0
+            a = gram + other.T @ (cu_minus_1[:, None] * other) + reg_eye
+            b = other.T @ (confidence[row] * preferences[row])
+            target[row] = np.linalg.solve(a, b)
+        return target
+
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])

--- a/tests/test_als.py
+++ b/tests/test_als.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+
+from recommender_systems.als import ALS
+from recommender_systems.base import Recommender
+
+
+def _two_cluster_implicit_feedback():
+    """50 users in two clusters, each interacting with 6 items from their cluster."""
+    rng = np.random.default_rng(0)
+    rows = []
+    for user in range(50):
+        cluster = 0 if user < 25 else 1
+        items = list(range(0, 25)) if cluster == 0 else list(range(25, 50))
+        for item in rng.choice(items, size=6, replace=False):
+            rows.append((user, int(item)))
+    return pd.DataFrame(rows, columns=["user_id", "item_id"]).assign(rating=1)
+
+
+def test_als_implements_interface():
+    assert issubclass(ALS, Recommender)
+
+
+def test_als_separates_clusters():
+    model = ALS(n_factors=8, epochs=10, regularization=0.01, alpha=40.0, random_state=0)
+    model.fit(_two_cluster_implicit_feedback())
+    recs = model.recommend(0, n=10)
+    cluster_0_hits = sum(1 for r in recs if r < 25)
+    assert cluster_0_hits >= 8, f"only {cluster_0_hits}/10 in the right cluster"
+
+
+def test_als_excludes_seen():
+    ratings = _two_cluster_implicit_feedback()
+    seen = set(ratings.loc[ratings["user_id"] == 0, "item_id"])
+    model = ALS(n_factors=4, epochs=3, random_state=0).fit(ratings)
+    recs = model.recommend(0, n=20)
+    assert not (set(recs) & seen)
+
+
+def test_als_unknown_user_returns_empty():
+    model = ALS(n_factors=4, epochs=3, random_state=0).fit(_two_cluster_implicit_feedback())
+    assert model.recommend(9999, n=5) == []
+
+
+def test_als_is_reproducible():
+    ratings = _two_cluster_implicit_feedback()
+    a = ALS(n_factors=4, epochs=3, random_state=42).fit(ratings).recommend(0, n=5)
+    b = ALS(n_factors=4, epochs=3, random_state=42).fit(ratings).recommend(0, n=5)
+    assert a == b
+
+
+def test_als_terminates_when_a_user_has_rated_every_item():
+    # ALS's closed-form solve doesn't have BPR's resample loop, but the
+    # all-rated case still belongs in the smoke set — the user gets no
+    # recommendations because every item is in the seen mask.
+    rows = [(0, item) for item in ("a", "b", "c")]
+    rows += [(1, "a"), (2, "b")]
+    ratings = pd.DataFrame(rows, columns=["user_id", "item_id"]).assign(rating=1)
+    model = ALS(n_factors=4, epochs=3, random_state=0).fit(ratings)
+    assert model.recommend(0, n=5) == []
+    assert model.recommend(1, n=2)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -2,6 +2,7 @@ import recommender_systems
 from recommender_systems import Recommender
 
 EXPECTED_RECOMMENDERS = [
+    "ALS",
     "BPR",
     "ContentBased",
     "HybridRecommender",


### PR DESCRIPTION
Closes #80. The remaining algorithm from ROADMAP's "Next" section.

## Algorithm

Hu/Koren/Volinsky 2008 implicit-feedback ALS:

- Binary preferences `p_ui = 1 if r_ui > 0 else 0`
- Per-cell confidence `c_ui = 1 + alpha * r_ui`
- Loss: `sum_{u,i} c_ui (p_ui - x_u . y_i)^2 + lambda (||X||^2 + ||Y||^2)`
- Alternate closed-form solves: `(Y^T C^u Y + lambda I) x_u = Y^T C^u p_u`, then the symmetric solve for `Y`.

Same implicit-feedback family as `BPR` (#16) but a different optimization story — alternating closed-form solves instead of SGD on a sigmoid margin — so it converges in many fewer epochs.

Subclasses `_MatrixBackedRecommender` so the unknown-user / seen-mask / top-n contract is inherited. Pure numpy, no new dependency.

## Tests (6 new, 113 total)

- Interface conformance.
- Cluster recovery on synthetic two-cluster data: top-10 lands ≥8/10 in the user's correct cluster. Same shape of test as BPR and TwoTowerCF.
- Exclude-seen via the inherited recommend.
- Unknown-user fast path returns `[]`.
- Seeded fits are reproducible.
- All-items-rated user returns `[]` (no termination issues since the closed-form solve has no resample loop).

## Exports

`ALS` is now importable from the package root and pinned by `test_public_api.py`. README's Algorithms table picks up the row.

## Local checks

```
ruff check src tests scripts            # clean
ruff format --check src tests scripts   # clean
mypy                                    # Success: no issues found in 17 source files
pytest                                  # 113 passed
```

Closes #80