### PR TITLE
chore: move ALS to ROADMAP's Shipped section

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,8 @@ built on top of it.
   interchangeable, a `MatrixBackedRecommender` base, and shared data utilities
   (`build_user_item_matrix`, `split_ratings`, `holdout_per_user`, `densest_subset`).
 - **Algorithms:** most-popular & mean-rating baselines, user/item k-NN, SVD matrix
-  factorization, implicit-feedback BPR, content-based (TF-IDF / count / binary features),
-  and a reciprocal-rank-fusion hybrid.
+  factorization, implicit-feedback BPR, ALS, content-based (TF-IDF / count / binary
+  features), and a reciprocal-rank-fusion hybrid.
 - **Evaluation:** precision@k, recall@k, MAP, NDCG, plus beyond-accuracy metrics
   (diversity, novelty, coverage, serendipity).
 - **Reproducible benchmarks** on MovieLens 100k and goodbooks-10k (committed tables +
@@ -27,8 +27,7 @@ recommendations, and a worked demo.
 ## Next
 
 - **Scale:** scipy-sparse user-item matrices so the neighborhood and matrix-factorization
-  models run on the full goodbooks-10k corpus, not just a subsample.
-- **More algorithms:** ALS.
-- **Product path (deferred):** an Open Library metadata client and a first-party
-  reading-signal model for the e-reader — commercial-safe, no scraped data.
+  models run on the full goodbooks-10k corpus, not just a subsample (#77).
+- **Product path (deferred):** an Open Library metadata client (#48) and a first-party
+  reading-signal model (#49) for the e-reader — commercial-safe, no scraped data.
 - **Release:** publish to PyPI.

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from recommender_systems import (
+    ALS,
     BPR,
     SVD,
     ContentBased,
@@ -40,6 +41,8 @@ def _build(cls):
         return cls(min_ratings=1)
     if cls is SVD:
         return cls(n_factors=2, random_state=0)
+    if cls is ALS:
+        return cls(n_factors=2, epochs=2, random_state=0)
     if cls is BPR:
         return cls(n_factors=2, epochs=2, random_state=0)
     if cls is ContentBased:
@@ -57,6 +60,7 @@ def _build(cls):
         ItemKNN,
         UserKNN,
         SVD,
+        ALS,
         BPR,
         ContentBased,
         HybridRecommender,

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 from recommender_systems import (
-    ALS,
     BPR,
     SVD,
     ContentBased,
@@ -41,8 +40,6 @@ def _build(cls):
         return cls(min_ratings=1)
     if cls is SVD:
         return cls(n_factors=2, random_state=0)
-    if cls is ALS:
-        return cls(n_factors=2, epochs=2, random_state=0)
     if cls is BPR:
         return cls(n_factors=2, epochs=2, random_state=0)
     if cls is ContentBased:
@@ -60,7 +57,6 @@ def _build(cls):
         ItemKNN,
         UserKNN,
         SVD,
-        ALS,
         BPR,
         ContentBased,
         HybridRecommender,


### PR DESCRIPTION
ALS landed via #82 but ROADMAP still listed it under `Next > More algorithms`. Moves it into `Shipped` (where the other algorithms live) and tags the remaining `Next` items with their tracking issues (#77 sparse matrices, #48 Open Library, #49 reading signal).

(JJ's #90 covers the CLI + persistence-test additions for ALS; I dropped my duplicate persistence change.)