### PR TITLE
Add ALS to the recsys CLI

### DIFF
--- a/src/recommender_systems/cli.py
+++ b/src/recommender_systems/cli.py
@@ -16,6 +16,7 @@ import sys
 from collections.abc import Callable, Sequence
 
 from recommender_systems import Recommender, split_ratings
+from recommender_systems.als import ALS
 from recommender_systems.baselines import MeanRating, MostPopular
 from recommender_systems.bpr import BPR
 from recommender_systems.datasets import load_movielens_100k
@@ -35,6 +36,7 @@ ALGORITHMS: dict[str, Callable[..., Recommender]] = {
     "user-knn": UserKNN,
     "svd": SVD,
     "bpr": BPR,
+    "als": ALS,
 }
 
 
@@ -73,7 +75,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _instantiate(name: str, seed: int) -> Recommender:
     factory = ALGORITHMS[name]
-    if name in {"bpr", "svd"}:
+    if name in {"als", "bpr", "svd"}:
         return factory(random_state=seed)
     return factory()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,3 +89,12 @@ def test_bpr_is_registered_and_seeded():
     model = cli._instantiate("bpr", seed=7)
     assert isinstance(model, BPR)
     assert model.random_state == 7
+
+
+def test_als_is_registered_and_seeded():
+    from recommender_systems.als import ALS
+
+    assert "als" in cli.ALGORITHMS
+    model = cli._instantiate("als", seed=7)
+    assert isinstance(model, ALS)
+    assert model.random_state == 7

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from recommender_systems import (
+    ALS,
     BPR,
     SVD,
     ContentBased,
@@ -38,6 +39,8 @@ def _content_features():
 def _build(cls):
     if cls is MeanRating:
         return cls(min_ratings=1)
+    if cls is ALS:
+        return cls(n_factors=2, epochs=2, random_state=0)
     if cls is SVD:
         return cls(n_factors=2, random_state=0)
     if cls is BPR:
@@ -58,6 +61,7 @@ def _build(cls):
         UserKNN,
         SVD,
         BPR,
+        ALS,
         ContentBased,
         HybridRecommender,
     ],

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 from recommender_systems import (
-    ALS,
     BPR,
     SVD,
     ContentBased,
@@ -39,8 +38,6 @@ def _content_features():
 def _build(cls):
     if cls is MeanRating:
         return cls(min_ratings=1)
-    if cls is ALS:
-        return cls(n_factors=2, epochs=2, random_state=0)
     if cls is SVD:
         return cls(n_factors=2, random_state=0)
     if cls is BPR:
@@ -61,7 +58,6 @@ def _build(cls):
         UserKNN,
         SVD,
         BPR,
-        ALS,
         ContentBased,
         HybridRecommender,
     ],


### PR DESCRIPTION
ALS landed (#82) after the CLI was written, so `recsys` didn't know it. Added `als` to the registry with `random_state` handling (like SVD/BPR) + a test; `list-algos` now shows all 7 ratings-based algorithms. (Persistence coverage for ALS is handled separately in #89.)