### PR TITLE
feat: add --version flag to the recsys CLI

### DIFF
--- a/src/recommender_systems/cli.py
+++ b/src/recommender_systems/cli.py
@@ -39,10 +39,13 @@ ALGORITHMS: dict[str, Callable[..., Recommender]] = {
 
 
 def build_parser() -> argparse.ArgumentParser:
+    from recommender_systems import __version__
+
     parser = argparse.ArgumentParser(
         prog="recsys",
         description="Train, recommend, and evaluate with recommender-systems.",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument(
         "--seed",
         type=int,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,3 +89,13 @@ def test_bpr_is_registered_and_seeded():
     model = cli._instantiate("bpr", seed=7)
     assert isinstance(model, BPR)
     assert model.random_state == 7
+
+
+def test_version_flag_prints_package_version(capsys):
+    import recommender_systems
+
+    with pytest.raises(SystemExit):
+        cli.main(["--version"])
+    out = capsys.readouterr().out
+    assert recommender_systems.__version__ in out
+    assert "recsys" in out


### PR DESCRIPTION
`recsys --version` now prints `recsys X.Y.Z` from `recommender_systems.__version__`, via argparse's built-in version action. Useful in bug reports and quick environment checks. One-line test pins the wiring.