### PR TITLE
chore: tighten mypy with strict_equality and warn_unreachable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,10 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
 no_implicit_optional = true
+strict_equality = true
 warn_redundant_casts = true
 warn_return_any = true
+warn_unreachable = true
 warn_unused_ignores = true
 ignore_missing_imports = true
 


### PR DESCRIPTION
Two extra mypy flags that pass cleanly on the current source — no code changes required:

- `strict_equality` catches comparisons that can't be true (e.g. `int == str`).
- `warn_unreachable` flags dead code after a raise / unconditional return.

Both are safe-by-default for a fully-typed codebase like ours, and complement the existing `disallow_untyped_defs` / `warn_return_any` strictness.