### PR TITLE
feat: better error message for malformed pickle in persistence.load

### DIFF
--- a/src/recommender_systems/persistence.py
+++ b/src/recommender_systems/persistence.py
@@ -19,8 +19,19 @@ def load(path: str | Path) -> Recommender:
     """Load a recommender previously saved with :func:`save`.
 
     Only load files you trust: unpickling executes arbitrary code.
+
+    Raises
+    ------
+    ValueError
+        If ``path`` does not contain a valid pickle stream.
+    TypeError
+        If the loaded object is not a :class:`Recommender`.
     """
-    obj = pickle.loads(Path(path).read_bytes())
+    raw = Path(path).read_bytes()
+    try:
+        obj = pickle.loads(raw)
+    except (pickle.UnpicklingError, EOFError) as exc:
+        raise ValueError(f"{path} is not a valid recommender file") from exc
     if not isinstance(obj, Recommender):
         raise TypeError(f"{path} does not contain a Recommender")
     return obj

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -78,3 +78,19 @@ def test_load_rejects_non_recommender(tmp_path):
 
     with pytest.raises(TypeError, match="Recommender"):
         load(path)
+
+
+def test_load_rejects_malformed_pickle(tmp_path):
+    path = tmp_path / "garbage.pkl"
+    path.write_bytes(b"this is not a pickle stream")
+
+    with pytest.raises(ValueError, match="not a valid recommender file"):
+        load(path)
+
+
+def test_load_rejects_empty_file(tmp_path):
+    path = tmp_path / "empty.pkl"
+    path.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="not a valid recommender file"):
+        load(path)


### PR DESCRIPTION
Previously a corrupt or empty file surfaced as a raw `pickle.UnpicklingError` / `EOFError` from `pickle` — opaque, and from a module the caller doesn't import directly. Mapped both to `ValueError` with the path in the message, symmetric with the existing 'not a Recommender' `TypeError` for valid-pickle-wrong-type.

Two new tests pin the malformed-pickle and empty-file paths.