### PR TITLE
docs: complete API reference with every public module

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[docs]"
+          pip install -e ".[docs,neural]"
       - name: Build site
         run: mkdocs build --strict --site-dir _site
       - uses: actions/upload-pages-artifact@v3

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,9 +18,29 @@
 
 ::: recommender_systems.svd
 
+### Bayesian Personalized Ranking
+
+::: recommender_systems.bpr
+
+### Alternating Least Squares
+
+::: recommender_systems.als
+
+### Two-tower neural CF
+
+::: recommender_systems.neural
+
 ### Content-based
 
 ::: recommender_systems.content
+
+### Hybrid
+
+::: recommender_systems.hybrid
+
+## Book-specific helpers
+
+::: recommender_systems.books
 
 ## Data
 
@@ -32,6 +52,10 @@
 
 ::: recommender_systems.data
 
+### Building feature matrices from text
+
+::: recommender_systems.features
+
 ## Evaluation metrics
 
 ::: recommender_systems.metrics
@@ -39,3 +63,7 @@
 ## Persistence
 
 ::: recommender_systems.persistence
+
+## Command-line interface
+
+::: recommender_systems.cli


### PR DESCRIPTION
`docs/api.md` was missing seven of our public modules — `bpr`, `als`, `neural`, `hybrid`, `books`, `features`, and `cli` — so the published API reference silently undersold the library. Adds an entry per module; mkdocstrings pulls the docstrings.

`.github/workflows/docs.yml` installs the `neural` extra alongside `docs` so mkdocstrings can import `recommender_systems.neural` (the module-level torch import guard raises and aborts the build otherwise).

Verified `mkdocs build --strict` locally.