### PR TITLE
Extract _PredictedScoreRecommender to DRY the score lookup

### DIFF
--- a/src/recommender_systems/als.py
+++ b/src/recommender_systems/als.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Hashable
-
 import numpy as np
 import pandas as pd
 
-from recommender_systems.base import _MatrixBackedRecommender
+from recommender_systems.base import _PredictedScoreRecommender
 from recommender_systems.data import build_user_item_matrix
 
 __all__ = ["ALS"]
 
 
-class ALS(_MatrixBackedRecommender):
+class ALS(_PredictedScoreRecommender):
     """Implicit-feedback matrix factorization via alternating least squares.
 
     Follows Hu, Koren & Volinsky (2008): binary preferences ``p_ui = 1 if r_ui > 0``
@@ -54,7 +52,6 @@ class ALS(_MatrixBackedRecommender):
         self.regularization = regularization
         self.alpha = alpha
         self.random_state = random_state
-        self._predicted: np.ndarray = np.empty((0, 0))
 
     def fit(self, ratings: pd.DataFrame) -> ALS:
         self._matrix = build_user_item_matrix(ratings, fill_value=0.0)
@@ -92,6 +89,3 @@ class ALS(_MatrixBackedRecommender):
             b = other.T @ (confidence[row] * preferences[row])
             target[row] = np.linalg.solve(a, b)
         return target
-
-    def _user_scores(self, user_id: Hashable) -> np.ndarray:
-        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])

--- a/src/recommender_systems/base.py
+++ b/src/recommender_systems/base.py
@@ -75,3 +75,18 @@ class _MatrixBackedRecommender(Recommender):
         scores[self._matrix.loc[user_id].to_numpy() > 0] = -np.inf
         order = np.argsort(-scores)
         return [self._matrix.columns[i] for i in order if np.isfinite(scores[i])][:n]
+
+
+class _PredictedScoreRecommender(_MatrixBackedRecommender):
+    """Matrix-backed recommender that precomputes a dense user-item score matrix.
+
+    Subclasses populate ``self._predicted`` (users x items, row-aligned with
+    ``self._matrix``) during :meth:`fit`; scoring a user is then a row lookup.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._predicted: np.ndarray = np.empty((0, 0))
+
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])

--- a/src/recommender_systems/content.py
+++ b/src/recommender_systems/content.py
@@ -8,13 +8,13 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
 
-from recommender_systems.base import _MatrixBackedRecommender
+from recommender_systems.base import _PredictedScoreRecommender
 from recommender_systems.data import build_user_item_matrix
 
 __all__ = ["ContentBased"]
 
 
-class ContentBased(_MatrixBackedRecommender):
+class ContentBased(_PredictedScoreRecommender):
     """Recommend items whose features resemble those a user has liked.
 
     The user's profile is a ratings-weighted mean of the features of the items they
@@ -36,7 +36,6 @@ class ContentBased(_MatrixBackedRecommender):
     def __init__(self, item_features: pd.DataFrame) -> None:
         super().__init__()
         self._item_features = item_features
-        self._predicted: np.ndarray = np.empty((0, 0))
         self._aligned_features: np.ndarray = np.empty((0, 0))
         self._profiles: np.ndarray = np.empty((0, 0))
         self._feature_names: list[str] = []
@@ -58,9 +57,6 @@ class ContentBased(_MatrixBackedRecommender):
         )
         self._predicted = np.asarray(cosine_similarity(self._profiles, self._aligned_features))
         return self
-
-    def _user_scores(self, user_id: Hashable) -> np.ndarray:
-        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])
 
     def explain(self, user_id: Hashable, item_id: Hashable, top_features: int = 3) -> str:
         """Return the top features driving ``item_id``'s score for ``user_id``.

--- a/src/recommender_systems/neural.py
+++ b/src/recommender_systems/neural.py
@@ -7,8 +7,6 @@ Optional — requires the ``neural`` extra:
 
 from __future__ import annotations
 
-from collections.abc import Hashable
-
 import numpy as np
 import pandas as pd
 
@@ -20,7 +18,7 @@ except ImportError as exc:  # pragma: no cover - import guard
         "TwoTowerCF requires torch. Install with: pip install 'recommender-systems[neural]'"
     ) from exc
 
-from recommender_systems.base import _MatrixBackedRecommender
+from recommender_systems.base import _PredictedScoreRecommender
 from recommender_systems.data import build_user_item_matrix
 
 __all__ = ["TwoTowerCF"]
@@ -39,7 +37,7 @@ class _TwoTowerNet(nn.Module):
         return scores
 
 
-class TwoTowerCF(_MatrixBackedRecommender):
+class TwoTowerCF(_PredictedScoreRecommender):
     """Two-tower neural CF trained with a BPR-style ranking loss.
 
     Each user and item is a learned embedding; the score for a (user, item) pair is
@@ -77,7 +75,6 @@ class TwoTowerCF(_MatrixBackedRecommender):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
         self.random_state = random_state
-        self._predicted: np.ndarray = np.empty((0, 0))
 
     def fit(self, ratings: pd.DataFrame) -> TwoTowerCF:
         if self.random_state is not None:
@@ -123,6 +120,3 @@ class TwoTowerCF(_MatrixBackedRecommender):
             scores = model.user_embed.weight @ model.item_embed.weight.T
             self._predicted = scores.numpy()
         return self
-
-    def _user_scores(self, user_id: Hashable) -> np.ndarray:
-        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])

--- a/src/recommender_systems/svd.py
+++ b/src/recommender_systems/svd.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Hashable
-
-import numpy as np
 import pandas as pd
 from sklearn.decomposition import TruncatedSVD
 
-from recommender_systems.base import _MatrixBackedRecommender
+from recommender_systems.base import _PredictedScoreRecommender
 from recommender_systems.data import build_user_item_matrix
 
 __all__ = ["SVD"]
 
 
-class SVD(_MatrixBackedRecommender):
+class SVD(_PredictedScoreRecommender):
     """Recommend from a low-rank reconstruction of the user-item matrix.
 
     Parameters
@@ -29,7 +26,6 @@ class SVD(_MatrixBackedRecommender):
         super().__init__()
         self.n_factors = n_factors
         self.random_state = random_state
-        self._predicted = np.empty((0, 0))
 
     def fit(self, ratings: pd.DataFrame) -> SVD:
         self._matrix = build_user_item_matrix(ratings, fill_value=0.0)
@@ -38,6 +34,3 @@ class SVD(_MatrixBackedRecommender):
         factors = model.fit_transform(self._matrix.to_numpy())
         self._predicted = factors @ model.components_
         return self
-
-    def _user_scores(self, user_id: Hashable) -> np.ndarray:
-        return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])


### PR DESCRIPTION
`SVD`, `ALS`, `ContentBased`, and `TwoTowerCF` all precompute a dense user-item score matrix in `fit` and had the *identical* `_user_scores` (`self._predicted[self._matrix.index.get_loc(user_id)]`) plus the same `_predicted` init. Pulled that into a `_PredictedScoreRecommender` base; the four now only populate `self._predicted`.

Names a real pattern (precompute-a-score-matrix recommenders, vs the per-call scorers like kNN/BPR) and removes the duplication. Behavior-preserving — 120 tests pass (the per-algorithm learning + persistence round-trip suites are unchanged). Also centralizes the score-row logic, which eases the eventual sparse work (#77).