### PR TITLE
chore: parameterize the harness catalog type as set[Hashable]

### DIFF
--- a/scripts/_harness.py
+++ b/scripts/_harness.py
@@ -7,6 +7,7 @@ writes a markdown table + chart to ``out_dir``. Individual benchmark scripts und
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -26,7 +27,7 @@ def _evaluate(
     model: Recommender,
     train: pd.DataFrame,
     test: pd.DataFrame,
-    catalog: set,
+    catalog: set[Hashable],
     *,
     k: int,
 ) -> dict[str, float]:


### PR DESCRIPTION
The `_evaluate` helper in `scripts/_harness.py` took a bare `set` (mypy-equivalent to `set[Any]`). Tightens to `set[Hashable]` to match how `recommender_systems.metrics.catalog_coverage` declares its parameter and how the callers actually build it (`set(ratings['item_id'].unique())`).