### PR TITLE
chore: add a pre-commit config for ruff lint and format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.14
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,16 @@ Thanks for contributing. This guide keeps the codebase consistent and reviewable
 python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
+pre-commit install
 ```
 
 The package uses a `src/` layout; the importable package is `recommender_systems`.
 
 ## Code style
 
-- Formatting and linting are handled by [Ruff](https://docs.astral.sh/ruff/). Run
-  `ruff format` and `ruff check` before committing; CI enforces both.
+- Formatting and linting are handled by [Ruff](https://docs.astral.sh/ruff/). The
+  `pre-commit install` step above wires `ruff` and `ruff format` to run on every
+  commit; CI enforces the same checks.
 - Line length is 100 characters. Target Python 3.10+.
 - Type-hint all public functions and methods.
 - Public functions and classes get NumPy-style docstrings (Parameters / Returns).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ docs = [
 ]
 dev = [
     "mypy>=1.8",
+    "pre-commit>=3.6",
     "pytest>=7.4",
     "pytest-cov>=4.1",
     "ruff>=0.4",


### PR DESCRIPTION
CONTRIBUTING.md already asks contributors to run `ruff format` and `ruff check` before pushing; CI runs the same two checks. Wiring them into pre-commit takes the manual step out of the loop and catches drift at commit time rather than at CI time.

- New `.pre-commit-config.yaml` with the standard `ruff-pre-commit` hooks (`ruff` with `--fix` and `ruff-format`), pinned to v0.15.14 to match the locally installed Ruff.
- Added `pre-commit>=3.6` to the `[dev]` extras so `pip install -e '.[dev]'` pulls it alongside the other dev tools.
- Updated the dev setup snippet in CONTRIBUTING.md with `pre-commit install` and reworded the code-style note.