### PR TITLE
docs: drop the trailing colon on parameter names in base.py docstrings

### DIFF
--- a/src/recommender_systems/base.py
+++ b/src/recommender_systems/base.py
@@ -25,7 +25,7 @@ class Recommender(ABC):
 
         Parameters
         ----------
-        ratings:
+        ratings
             Interaction data with at least ``user_id``, ``item_id`` and ``rating`` columns.
 
         Returns
@@ -40,9 +40,9 @@ class Recommender(ABC):
 
         Parameters
         ----------
-        user_id:
+        user_id
             The user to recommend for.
-        n:
+        n
             Maximum number of items to return.
 
         Returns


### PR DESCRIPTION
Every other module renders docstring parameters as bare names (`n_factors`, `predicted`, `user_col`, etc.); only `base.py` was still carrying a trailing colon (`ratings:`, `user_id:`, `n:`) from an early draft.

The NumPy docstring style mkdocstrings renders expects either `name` or `name : type` — the trailing-colon form is neither and surfaces as literal text on the API page. Aligns `base.py` with the rest of the codebase.