### PR TITLE
bench: baseline fit-time benchmarks + profile findings (phase 1.1)

### DIFF
--- a/benchmarks/profile.md
+++ b/benchmarks/profile.md
@@ -1,0 +1,118 @@
+# Phase 1.1 baseline — where the time actually goes
+
+Phase 1.1 of the [evolution arc](../docs/evolution/) is "measure before
+cutting." No code is rewritten in this phase. The numbers below are the
+ground truth that justifies — or refutes — every optimization the later
+phases propose.
+
+## Environment
+
+| | |
+|---|---|
+| Python | 3.14.3 |
+| Platform | macOS 15.7.1, arm64 (Apple Silicon) |
+| numpy | 2.4.6 |
+| pandas | 3.0.3 |
+| scikit-learn | 1.8.0 |
+| scipy | 1.17.1 |
+
+Hardware-sensitive numbers. Re-run on your machine before drawing conclusions
+about absolute timings; the *ratios* are what carry across hardware.
+
+## Reproducing
+
+```bash
+pip install -e ".[dev]"
+pytest tests/benchmarks/ -m benchmark --benchmark-only \
+    --benchmark-columns=mean,stddev,rounds --benchmark-warmup=on
+```
+
+Benchmarks are skipped by default (`-m 'not benchmark'` in `pyproject.toml`)
+and excluded from CI — wall-clock timings are too noisy on shared runners.
+
+## Fit time, MovieLens 100k
+
+100,000 ratings, 943 users, 1,682 items. Iterative algorithms use 5 epochs
+and `n_factors=16` so the suite runs in under a minute.
+
+| Algorithm     | Mean fit time | vs. MostPopular |
+|---------------|---------------|-----------------|
+| MostPopular   | 16.1 ms       | 1.0×            |
+| MeanRating    | 16.5 ms       | 1.0×            |
+| SVD (k=20)    | 46.1 ms       | 2.9×            |
+| UserKNN (k=20)| 74.0 ms       | 4.6×            |
+| ItemKNN (k=20)| 140.9 ms      | 8.8×            |
+| ALS (16/5)    | 473.2 ms      | 29×             |
+| **BPR (16/5)**| **4,503.4 ms**| **280×**        |
+
+**BPR dominates by an order of magnitude.** Everything else fits in under
+half a second; BPR alone takes 4.5 seconds for the same dataset with the
+same epoch budget.
+
+## Where BPR spends its time
+
+`cProfile`, sorted by cumulative time:
+
+```
+         507806 function calls in 4.687 seconds
+
+   ncalls  tottime  percall  cumtime  percall function
+        1    0.674    0.674    4.687    4.687 bpr.py:56(fit)
+   500000    3.975    0.000    3.975    0.000 bpr.py:80(_step)
+        1    0.000    0.000    0.034    0.034 data.py:18(build_user_item_matrix)
+```
+
+500,000 calls to `_step` — one per (positive interaction × epoch). Each
+call is a handful of numpy vector ops on tiny 16-dim arrays; the work is
+trivial but the Python interpreter overhead per call dominates.
+
+| Bucket                          | Time    | Share |
+|---------------------------------|---------|-------|
+| `_step` inner loop              | 3.975 s | **85%** |
+| `fit` outer loop (resampling, indexing) | 0.674 s | 14%   |
+| Data prep (pandas pivot)        | 0.034 s | <1%   |
+
+**Reading:** the `_step` body is too small to vectorize across (it mutates
+shared embedding rows in-place), so numpy won't help. The interpreter
+itself is the bottleneck. A compiled inner loop is the only intervention
+that matters here.
+
+## Where ALS spends its time
+
+```
+         401511 function calls in 0.498 seconds
+
+   ncalls  tottime  percall  cumtime  percall function
+        1    0.006    0.006    0.498    0.498 als.py:56(fit)
+       10    0.304    0.030    0.455    0.046 als.py:75(_solve_side)
+    13125    0.077    0.000    0.151    0.000 numpy.linalg.solve
+```
+
+`_solve_side` is 91% of ALS fit, but ALS fit is itself 9× *faster* than
+BPR. Of `_solve_side`'s time, only one-third is `numpy.linalg.solve` — the
+rest is the per-row matrix prep (`cu_minus_1 * other`, the Python loop
+itself).
+
+A pre-Phase-1.1 expectation was that ALS would be the obvious Phase 2
+target. The numbers say otherwise: ALS is already fast enough that
+rewriting it would not be the highest-leverage move.
+
+## What this means for Phase 2
+
+The original plan named ALS as Phase 2's target. The data points elsewhere.
+
+| Candidate           | Speed today | Inner loop characteristics       | Phase 2 priority |
+|---------------------|-------------|----------------------------------|------------------|
+| **BPR `_step`**     | 4.5 s       | 500k Python calls × tiny vector op | **First**        |
+| ALS `_solve_side`   | 0.5 s       | 13k Python calls × 16×16 linalg    | Defer, possibly Phase 3 with sparse work |
+| ItemKNN cosine sim  | 0.14 s      | One sklearn call, already C-backed | Skip — no win available |
+| Everything else     | < 0.1 s     | Negligible                       | Skip            |
+
+The Phase 2 PR should rewrite `BPR._step` (and the negative-resample loop
+that surrounds it) in Rust+PyO3. ALS becomes a Phase 3 candidate *if*
+profiling on goodbooks-full — once Phase 3's sparse work makes that
+tractable — shows it on the critical path. If it doesn't, we let ALS be.
+
+This is exactly the kind of course-correction Phase 1.1 exists to enable.
+The portfolio narrative reads cleaner this way too: *measured first,
+then targeted the actual hot path* beats *guessed correctly the first time*.

--- a/benchmarks/profile.md
+++ b/benchmarks/profile.md
@@ -114,5 +114,3 @@ profiling on goodbooks-full — once Phase 3's sparse work makes that
 tractable — shows it on the critical path. If it doesn't, we let ALS be.
 
 This is exactly the kind of course-correction Phase 1.1 exists to enable.
-The portfolio narrative reads cleaner this way too: *measured first,
-then targeted the actual hot path* beats *guessed correctly the first time*.

--- a/docs/evolution/01-1-bench-baseline.md
+++ b/docs/evolution/01-1-bench-baseline.md
@@ -30,7 +30,7 @@ Three deliverables:
 
 | Option | Rejected because |
 |---|---|
-| Skip Phase 1.1, start Rust rewrite of ALS | The original plan assumed ALS was the hot path. Without numbers this is an opinion, not a finding. The whole portfolio thesis depends on "measured first." |
+| Skip Phase 1.1, start Rust rewrite of ALS | Without numbers, "ALS is the hot path" is an opinion. The whole rewrite plan rests on knowing which inner loop actually dominates. |
 | Use `timeit` ad-hoc, don't commit a suite | Reproducibility matters. A reviewer should be able to run the suite and see whether the claims hold. Ad-hoc timings rot. |
 | Run benchmarks in CI | Wall-clock numbers on GitHub Actions are too noisy to gate on. The committed baseline is the source of truth; CI verifies correctness, not speed. |
 | Use `asv` (airspeed velocity) instead of `pytest-benchmark` | `asv` is the right tool when you want a time-series of regression detection across commits. `pytest-benchmark` is right when you want one snapshot per phase. We have phases, not a continuous regression budget. |
@@ -51,8 +51,7 @@ sparse work on goodbooks-full puts it on the critical path.
 
 This course-correction is the *reason* Phase 1.1 exists. If the data had
 confirmed the original guess we'd have proceeded; instead it pointed at
-a better target, and the portfolio narrative is stronger for showing the
-adjustment.
+a better target.
 
 ## What's not in scope
 

--- a/docs/evolution/01-1-bench-baseline.md
+++ b/docs/evolution/01-1-bench-baseline.md
@@ -1,0 +1,69 @@
+# Phase 1.1 — measure before cutting
+
+**Status:** shipped.
+**Tag:** `v0.1.1` (planned).
+**Code change:** none in `src/`. New `tests/benchmarks/` suite and
+`benchmarks/profile.md`.
+
+## Context
+
+The library has reached the "useful but unoptimized" state. Several
+optimization directions are obvious in principle — Rust kernels, sparse
+matrices, GPU. Picking which one to do *first* requires evidence, and the
+repo has none. There are committed benchmark *result tables* in
+`benchmarks/results.md`, but those measure recommendation quality, not
+where wall-clock time goes during training.
+
+## Decision
+
+Ship a benchmark + profile baseline as its own phase, before any rewriting.
+Three deliverables:
+
+1. A `pytest-benchmark` suite under `tests/benchmarks/` covering fit time
+   for every algorithm in the library on MovieLens 100k.
+2. A `benchmarks/profile.md` document that records, for the slow ones:
+   a `cProfile` breakdown showing which function consumes the time.
+3. A `not benchmark` filter in `pyproject.toml` so the timing suite is
+   opt-in (it's wall-clock-sensitive; CI on shared runners would be noisy).
+
+## Options considered
+
+| Option | Rejected because |
+|---|---|
+| Skip Phase 1.1, start Rust rewrite of ALS | The original plan assumed ALS was the hot path. Without numbers this is an opinion, not a finding. The whole portfolio thesis depends on "measured first." |
+| Use `timeit` ad-hoc, don't commit a suite | Reproducibility matters. A reviewer should be able to run the suite and see whether the claims hold. Ad-hoc timings rot. |
+| Run benchmarks in CI | Wall-clock numbers on GitHub Actions are too noisy to gate on. The committed baseline is the source of truth; CI verifies correctness, not speed. |
+| Use `asv` (airspeed velocity) instead of `pytest-benchmark` | `asv` is the right tool when you want a time-series of regression detection across commits. `pytest-benchmark` is right when you want one snapshot per phase. We have phases, not a continuous regression budget. |
+| Profile in production with `py-spy` flamegraphs | Worth doing later; cProfile's function-level view is enough to answer "which function is the hot path." |
+
+## The finding that mattered
+
+The original plan named ALS's `_solve_side` as Phase 2's Rust target.
+The measurements say otherwise:
+
+- **BPR fit: 4,503 ms.** `_step` is 85% of the time. 500,000 Python
+  function calls on tiny vector ops; the interpreter is the bottleneck.
+- **ALS fit: 473 ms.** `_solve_side` is 91% of *that* but ALS as a whole
+  is 9× *faster* than BPR.
+
+Phase 2 will rewrite BPR, not ALS. ALS becomes a Phase 3 candidate if
+sparse work on goodbooks-full puts it on the critical path.
+
+This course-correction is the *reason* Phase 1.1 exists. If the data had
+confirmed the original guess we'd have proceeded; instead it pointed at
+a better target, and the portfolio narrative is stronger for showing the
+adjustment.
+
+## What's not in scope
+
+- No optimization of any algorithm — that's Phase 2 onward.
+- No flamegraphs. `cProfile` answers the question being asked
+  (which function is the hot path?). Flamegraphs are richer but slower
+  to read and to commit; defer until we need them.
+- No `goodbooks-10k` benchmarks. The dataset requires subsampling for the
+  dense algorithms, which would bias the comparison. Phase 3 lands sparse
+  variants; *then* the full corpus becomes the benchmark frame.
+
+## Results
+
+See `benchmarks/profile.md` for the table and profile output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ docs = [
 dev = [
     "mypy>=1.8",
     "pytest>=7.4",
+    "pytest-benchmark>=4.0",
     "pytest-cov>=4.1",
     "ruff>=0.4",
 ]
@@ -74,9 +75,12 @@ select = ["E", "F", "I", "UP", "B", "SIM", "C4", "N", "RUF"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers -m 'not benchmark'"
 testpaths = ["tests"]
 pythonpath = ["src"]
+markers = [
+    "benchmark: timing-sensitive benchmark; skipped by default, run with -m benchmark",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,25 @@
+"""Fixtures for the algorithm benchmark suite.
+
+The benchmarks live in ``tests/benchmarks/`` and are excluded from the default
+``pytest`` run by the ``not benchmark`` marker filter in ``pyproject.toml``.
+Run them with ``pytest tests/benchmarks/ -m benchmark`` (or
+``pytest --benchmark-only``).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from recommender_systems.datasets import load_movielens_100k
+
+
+@pytest.fixture(scope="session")
+def movielens_100k() -> pd.DataFrame:
+    """The full MovieLens 100k ratings frame.
+
+    Cached at session scope because dataset I/O dominates wall time for the
+    fast algorithms (MostPopular, MeanRating) and we don't want to re-read
+    the file between benchmarks.
+    """
+    return load_movielens_100k()

--- a/tests/benchmarks/test_fit_speed.py
+++ b/tests/benchmarks/test_fit_speed.py
@@ -1,0 +1,53 @@
+"""Benchmark how long each algorithm takes to fit MovieLens 100k.
+
+Run with::
+
+    pytest tests/benchmarks/ -m benchmark --benchmark-only --benchmark-columns=mean,stddev,rounds
+
+The committed baseline lives in ``benchmarks/profile.md``. CI does not run
+benchmarks (they are wall-time-sensitive and noisy on shared hardware); the
+suite exists so any local rewrite has a concrete number to beat.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from recommender_systems.als import ALS
+from recommender_systems.baselines import MeanRating, MostPopular
+from recommender_systems.bpr import BPR
+from recommender_systems.neighborhood import ItemKNN, UserKNN
+from recommender_systems.svd import SVD
+
+pytestmark = pytest.mark.benchmark
+
+
+def test_most_popular_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    benchmark(lambda: MostPopular().fit(movielens_100k))
+
+
+def test_mean_rating_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    benchmark(lambda: MeanRating().fit(movielens_100k))
+
+
+def test_item_knn_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    benchmark(lambda: ItemKNN().fit(movielens_100k))
+
+
+def test_user_knn_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    benchmark(lambda: UserKNN().fit(movielens_100k))
+
+
+def test_svd_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    benchmark(lambda: SVD(n_factors=20, random_state=0).fit(movielens_100k))
+
+
+def test_bpr_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    # Five epochs keeps the benchmark under ~30s on a laptop while still
+    # exercising the full inner loop.
+    benchmark(lambda: BPR(n_factors=16, epochs=5, random_state=0).fit(movielens_100k))
+
+
+def test_als_fit(benchmark, movielens_100k: pd.DataFrame) -> None:
+    benchmark(lambda: ALS(n_factors=16, epochs=5, random_state=0).fit(movielens_100k))


### PR DESCRIPTION
## Phase 1.1 — measure before cutting

First phase of the [evolution arc](../blob/bench/phase-1-1-baseline/docs/evolution/01-1-bench-baseline.md): no code rewritten anywhere in `src/`, only the infrastructure and measurement that justifies the rewrites in later phases.

### What's in the PR
- `tests/benchmarks/` — a `pytest-benchmark` suite covering fit time for every algorithm on MovieLens 100k. Marked `benchmark` and **opt-in only** (`pyproject.toml` filters them out by default; CI does not run them — wall-clock timings on shared runners are too noisy to gate on).
- `benchmarks/profile.md` — the committed baseline numbers plus a `cProfile` breakdown for the two slowest algorithms.
- `docs/evolution/01-1-bench-baseline.md` — the ADR for this phase: context, options considered, the finding, what's deliberately out of scope.
- `pyproject.toml` — adds `pytest-benchmark` to `[dev]`, registers the `benchmark` marker, and filters it from the default run.

### The finding that matters

The original plan named ALS as Phase 2's Rust target. The numbers say otherwise:

| Algorithm | Mean fit | vs MostPopular |
|---|---|---|
| MostPopular | 16 ms | 1× |
| SVD | 46 ms | 3× |
| UserKNN | 74 ms | 5× |
| ItemKNN | 141 ms | 9× |
| ALS | 473 ms | 29× |
| **BPR** | **4,503 ms** | **280×** |

BPR's `_step` is 85% of its fit time — 500,000 Python calls on tiny vector ops; pure interpreter overhead. ALS is 9× faster than BPR despite being 29× slower than MostPopular.

**Phase 2 retargets to BPR `_step`, not ALS `_solve_side`.** ALS becomes a Phase 3 candidate *if* sparse work on goodbooks-full puts it on the critical path.

### Verification
- `ruff check` / `ruff format --check` clean
- `mypy` clean
- `pytest` — 130 passed, 7 benchmark tests deselected (as designed)
- `pytest tests/benchmarks/ -m benchmark --benchmark-only` produces the numbers in `profile.md`