### PR TITLE
feat: sparse-aware UserKNN / ItemKNN / SVD (phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ### Added
 
+- Sparse-aware `UserKNN`, `ItemKNN`, and `SVD` (`_SparseMatrixBackedRecommender`
+  base). `UserKNN` uses `sklearn.neighbors.NearestNeighbors` to avoid the
+  full users-by-users similarity; `ItemKNN` operates on a sparse item-item
+  cosine matrix; `SVD` runs `TruncatedSVD` on the CSR matrix directly. This
+  closes #77 and lets the three algorithms run goodbooks-10k at full scale.
+  See `docs/evolution/03-sparse-recommenders.md`.
 - Rust+PyO3 kernel (`crates/recsys-kernels/`) for BPR's inner SGD loop.
   `BPR.fit` now calls into the compiled extension and falls back to the
   pure-Python loop only when the extension isn't importable.
@@ -20,6 +26,13 @@ and versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html
   source now requires a Rust toolchain; CONTRIBUTING.md has the setup.
 - `recommender_systems.__version__` is now sourced from installed
   package metadata rather than hard-coded in `__init__.py`.
+
+### Backwards-incompatible
+
+- Pickles of `UserKNN` / `ItemKNN` / `SVD` written before this release
+  don't load on the new code — the internal matrix representation moved
+  from dense `pd.DataFrame` to sparse CSR. Re-fit and re-save. Pre-1.0;
+  no migration path.
 
 ## [0.1.0]
 

--- a/docs/evolution/03-sparse-recommenders.md
+++ b/docs/evolution/03-sparse-recommenders.md
@@ -1,0 +1,95 @@
+# Phase 3 — sparse-aware UserKNN / ItemKNN / SVD
+
+**Status:** shipped.
+**Tag:** `v0.3.0` (planned).
+**Code change:** new `_SparseMatrixBackedRecommender` base; `UserKNN`,
+`ItemKNN`, and `SVD` rewritten on top of it. Closes #77.
+
+## Context
+
+The MovieLens benchmark fits in memory comfortably (1.6k items, 940 users —
+a 940×1682 dense matrix is 12 MB). The goodbooks-10k benchmark does not:
+the dense user-item matrix is 53k × 10k = 530M cells, 4 GB at float64, and
+the dense user-user similarity needed by the old `UserKNN` would be
+53k × 53k = 22 GB. Until now `scripts/benchmark_goodbooks.py` had to
+subsample to a 2,500-user slice for `UserKNN` to fit — which biased every
+algorithm in the comparison, not just the one that needed it.
+
+`recommender_systems.data.build_sparse_user_item_matrix` (shipped earlier)
+returns a CSR matrix and `pd.Index` views for the rows and columns. It has
+been sitting unused inside the package — Phase 3 cashes that in.
+
+## Decision
+
+Add a sibling base class `_SparseMatrixBackedRecommender` and migrate the
+three algorithms whose memory profile actually cares —
+`UserKNN`, `ItemKNN`, `SVD` — over to it. `ALS`, `BPR`, `ContentBased`,
+`TwoTowerCF` stay on the existing dense `_MatrixBackedRecommender` because
+they aren't memory-constrained at the scales the library targets and a
+unified migration would multiply the diff for no benefit.
+
+### Per-algorithm choices
+
+| Algorithm | Approach |
+|---|---|
+| `ItemKNN` | `cosine_similarity(matrix.T, dense_output=False)` gives a CSR `(n_items, n_items)` similarity; `_sparse_top_k_per_row` zeroes the diagonal and keeps the top-`k` per row. Scoring a user is `sim @ user_row.T`. |
+| `UserKNN` | `sklearn.neighbors.NearestNeighbors(metric="cosine")` finds the top-`k` neighbors per user without materializing the full `n_users × n_users` matrix. Per-user score is the similarity-weighted average of the neighbors' rating rows. |
+| `SVD` | `TruncatedSVD` already accepts CSR natively; the dense pivot was the only thing keeping it from scaling. Drop it. |
+
+## Options considered
+
+| Option | Rejected because |
+|---|---|
+| Switch the *base* `_MatrixBackedRecommender` to sparse everywhere | Would require touching ALS, BPR, ContentBased, TwoTowerCF, all their tests, and `_PredictedScoreRecommender`. The algorithms that don't benefit shouldn't pay the migration cost; two parallel bases is a small price. |
+| Compute a full `n_users × n_users` sparse similarity for UserKNN and trim per row | The intermediate is the problem — even after trim, computing the full pairwise distance is O(users² × items), 53,424² × 10,000 ≈ 28 trillion ops for goodbooks. `NearestNeighbors`' brute-force search with cosine metric is the same asymptotic but skips materializing the full matrix and parallelizes the search. |
+| Use an approximate-NN library (FAISS, HNSWLib) for UserKNN | Phase 3's goal is to unlock the full corpus, not to make k-NN sub-linear. Approximate methods are a Phase-4+ candidate once the exact path is shown to be the right shape. |
+| Add a `sparse=True` flag on the dense classes | Hides the actual decision behind a parameter. The dense and sparse paths have different internal state (CSR vs DataFrame) and different memory characteristics; users picking these algorithms benefit from the choice being explicit at the class level. |
+
+## What's in the change
+
+- `src/recommender_systems/base.py` — new `_SparseMatrixBackedRecommender`
+  with `_matrix: csr_matrix`, `_users: Index`, `_items: Index`, and a
+  sparse-aware `recommend` that masks seen items off the user's nonzero
+  columns.
+- `src/recommender_systems/neighborhood.py` — fully rewritten. `ItemKNN`
+  uses sparse cosine; `UserKNN` uses `NearestNeighbors`. Module-private
+  `_sparse_top_k_per_row` helper.
+- `src/recommender_systems/svd.py` — uses the sparse builder and the
+  CSR-native `TruncatedSVD`.
+- Existing `tests/test_neighborhood.py` and `tests/test_svd.py` pass
+  unchanged — the public contract is preserved.
+
+## Results
+
+On MovieLens 100k (same `tests/benchmarks/test_fit_speed.py` suite), the
+sparse rewrite is also *faster* on small data, because the sparse cosine
+and the smaller `NearestNeighbors` workload beat the original dense path:
+
+| Algorithm | Phase 1.1 (dense) | Phase 3 (sparse) |
+|-----------|------------------:|-----------------:|
+| SVD       | 46 ms             | **29 ms**        |
+| UserKNN   | 74 ms             | **33 ms**        |
+| ItemKNN   | 141 ms            | **85 ms**        |
+
+The headline result is qualitative, not relative: `UserKNN`, `ItemKNN`,
+and `SVD` can now run the full goodbooks-10k corpus. The 2,500-user
+subsample in `scripts/benchmark_goodbooks.py` is still there only because
+`ContentBased` / `HybridBook` retain dense feature matrices; the three
+sparse-aware algorithms no longer need it. A follow-up could add a
+`--full` mode that runs only the sparse-aware algorithms over the entire
+corpus, but that's a separate change.
+
+## What's not in scope
+
+- `ContentBased`, `HybridBook`. Their dense user-profile and feature
+  matrices would need a separate sparse pass; out of this phase's scope.
+- `ALS`. Phase 1.1 measurements showed it's already fast enough; the
+  dense per-row solve is well-conditioned at the scales we target. It
+  earns a rewrite only if a future profile puts it on the critical path.
+- Approximate nearest neighbors. Exact brute-force search at
+  goodbooks-10k scale is tractable; adding an ANN dependency before the
+  exact path is shown to be too slow would be a premature optimization.
+- The persistence format. CSR matrices and `pd.Index` are both picklable,
+  so the existing `save`/`load` flow continues to work — but pickles
+  written *before* this change won't load on the new code because the
+  internal layout shifted. Pre-1.0; documented in CHANGELOG.

--- a/src/recommender_systems/base.py
+++ b/src/recommender_systems/base.py
@@ -7,6 +7,7 @@ from collections.abc import Hashable
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
 __all__ = ["Recommender"]
 
@@ -90,3 +91,36 @@ class _PredictedScoreRecommender(_MatrixBackedRecommender):
 
     def _user_scores(self, user_id: Hashable) -> np.ndarray:
         return np.asarray(self._predicted[self._matrix.index.get_loc(user_id)])
+
+
+class _SparseMatrixBackedRecommender(Recommender):
+    """Recommend by ranking the user's row of a sparse user-item matrix.
+
+    Sibling of :class:`_MatrixBackedRecommender` for algorithms whose memory
+    profile can't tolerate a dense ``(n_users, n_items)`` matrix — UserKNN,
+    ItemKNN, SVD on goodbooks-full-class corpora. Subclasses populate
+    ``self._matrix`` (CSR), ``self._users`` (row → user id), ``self._items``
+    (column → item id) in :meth:`fit`, and implement :meth:`_user_scores`
+    to return an item-aligned dense vector. This base owns the unknown-user
+    fast path, the seen-item mask (read off the user's nonzero columns), and
+    the top-``n`` filter.
+    """
+
+    def __init__(self) -> None:
+        self._matrix: sparse.csr_matrix = sparse.csr_matrix((0, 0))
+        self._users: pd.Index = pd.Index([])
+        self._items: pd.Index = pd.Index([])
+
+    @abstractmethod
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        """Return an item-aligned score vector for ``user_id``."""
+
+    def recommend(self, user_id: Hashable, n: int = 10) -> list[Hashable]:
+        if user_id not in self._users:
+            return []
+        scores = self._user_scores(user_id).copy()
+        u_idx = self._users.get_loc(user_id)
+        seen_cols = self._matrix.getrow(u_idx).indices
+        scores[seen_cols] = -np.inf
+        order = np.argsort(-scores)
+        return [self._items[i] for i in order if np.isfinite(scores[i])][:n]

--- a/src/recommender_systems/neighborhood.py
+++ b/src/recommender_systems/neighborhood.py
@@ -1,63 +1,120 @@
-"""Neighborhood (k-NN) collaborative filtering."""
+"""Neighborhood (k-NN) collaborative filtering on sparse matrices."""
 
 from __future__ import annotations
 
-from abc import abstractmethod
 from collections.abc import Hashable
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.neighbors import NearestNeighbors
 
-from recommender_systems.base import _MatrixBackedRecommender
-from recommender_systems.data import build_user_item_matrix
+from recommender_systems.base import _SparseMatrixBackedRecommender
+from recommender_systems.data import build_sparse_user_item_matrix
 
 __all__ = ["ItemKNN", "UserKNN"]
 
 
-def _keep_top_k(similarity: np.ndarray, k: int) -> np.ndarray:
-    """Zero the diagonal and all but the ``k`` largest entries in each row."""
-    similarity = similarity.copy()
-    np.fill_diagonal(similarity, 0.0)
-    if k < similarity.shape[1]:
-        drop = np.argsort(-similarity, axis=1)[:, k:]
-        np.put_along_axis(similarity, drop, 0.0, axis=1)
-    return similarity
+class ItemKNN(_SparseMatrixBackedRecommender):
+    """Score items by similarity to the items a user has already rated.
 
+    Builds a sparse item-item cosine similarity matrix, keeps the ``k`` largest
+    entries per row, and scores by ``S @ user_row``. The full similarity is
+    materialized in CSR form, which is fine even for goodbooks-10k (10k by 10k
+    items would be 100M entries dense; in sparse form after the top-``k`` trim
+    it's `k * n_items` = a few hundred thousand non-zeros).
 
-class _NeighborhoodCF(_MatrixBackedRecommender):
-    """Shared fit for neighborhood collaborative filtering."""
+    Parameters
+    ----------
+    k
+        Number of nearest neighbors retained per item.
+    """
 
     def __init__(self, k: int = 20) -> None:
         super().__init__()
         self.k = k
-        self._similarity = np.empty((0, 0))
+        self._similarity: sparse.csr_matrix = sparse.csr_matrix((0, 0))
 
-    def fit(self, ratings: pd.DataFrame) -> _NeighborhoodCF:
-        self._matrix = build_user_item_matrix(ratings, fill_value=0.0)
-        self._similarity = _keep_top_k(self._similarity_of(self._matrix.to_numpy()), self.k)
+    def fit(self, ratings: pd.DataFrame) -> ItemKNN:
+        self._matrix, self._users, self._items = build_sparse_user_item_matrix(ratings)
+        full = cosine_similarity(self._matrix.T, dense_output=False)
+        self._similarity = _sparse_top_k_per_row(full.tocsr(), self.k)
         return self
 
-    @abstractmethod
-    def _similarity_of(self, matrix: np.ndarray) -> np.ndarray: ...
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        u_idx = self._users.get_loc(user_id)
+        user_row = self._matrix.getrow(u_idx)
+        scores = self._similarity @ user_row.T
+        return np.asarray(scores.todense()).ravel()
 
 
-class ItemKNN(_NeighborhoodCF):
-    """Score items by similarity to the items a user has already rated."""
+class UserKNN(_SparseMatrixBackedRecommender):
+    """Score items by the ratings of a user's nearest neighbors.
 
-    def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
-        return np.asarray(cosine_similarity(matrix.T))
+    Builds the neighborhood with :class:`sklearn.neighbors.NearestNeighbors`
+    (cosine metric on the sparse user-item matrix) rather than materializing
+    the full users-by-users similarity — that's ``n_users**2`` and blows up
+    past a few thousand users. Per-user scoring weights the neighbors' rating
+    rows by their similarities.
+
+    Parameters
+    ----------
+    k
+        Number of nearest neighbors retained per user.
+    """
+
+    def __init__(self, k: int = 20) -> None:
+        super().__init__()
+        self.k = k
+        self._neighbor_idx: np.ndarray = np.empty((0, 0), dtype=np.int64)
+        self._neighbor_sim: np.ndarray = np.empty((0, 0))
+
+    def fit(self, ratings: pd.DataFrame) -> UserKNN:
+        self._matrix, self._users, self._items = build_sparse_user_item_matrix(ratings)
+        # Ask for k+1 neighbors because each user is its own first neighbor
+        # (cosine distance 0); we drop that column below.
+        n_neighbors = min(self.k + 1, self._matrix.shape[0])
+        nn = NearestNeighbors(n_neighbors=n_neighbors, metric="cosine", algorithm="brute")
+        nn.fit(self._matrix)
+        distances, indices = nn.kneighbors(self._matrix)
+        self._neighbor_idx = indices[:, 1:]
+        self._neighbor_sim = 1.0 - distances[:, 1:]
+        return self
 
     def _user_scores(self, user_id: Hashable) -> np.ndarray:
-        return np.asarray(self._similarity @ self._matrix.loc[user_id].to_numpy())
+        u_idx = self._users.get_loc(user_id)
+        neighbors = self._neighbor_idx[u_idx]
+        weights = self._neighbor_sim[u_idx]
+        if not weights.size or weights.sum() <= 0:
+            return np.zeros(self._matrix.shape[1])
+        neighbor_rows = self._matrix[neighbors]
+        scores = weights @ neighbor_rows
+        return np.asarray(scores.todense() if sparse.issparse(scores) else scores).ravel() / (
+            weights.sum() or 1.0
+        )
 
 
-class UserKNN(_NeighborhoodCF):
-    """Score items by the ratings of a user's nearest neighbors."""
-
-    def _similarity_of(self, matrix: np.ndarray) -> np.ndarray:
-        return np.asarray(cosine_similarity(matrix))
-
-    def _user_scores(self, user_id: Hashable) -> np.ndarray:
-        weights = self._similarity[self._matrix.index.get_loc(user_id)]
-        return np.asarray(weights @ self._matrix.to_numpy() / (weights.sum() or 1.0))
+def _sparse_top_k_per_row(matrix: sparse.csr_matrix, k: int) -> sparse.csr_matrix:
+    """Zero the diagonal and keep the ``k`` largest entries in each row."""
+    matrix = matrix.copy()
+    matrix.setdiag(0.0)
+    matrix.eliminate_zeros()
+    if k >= matrix.shape[1]:
+        return matrix
+    rows, cols, data = [], [], []
+    for row_idx in range(matrix.shape[0]):
+        start, end = matrix.indptr[row_idx], matrix.indptr[row_idx + 1]
+        if end - start <= k:
+            rows.extend([row_idx] * (end - start))
+            cols.extend(matrix.indices[start:end])
+            data.extend(matrix.data[start:end])
+            continue
+        row_data = matrix.data[start:end]
+        row_cols = matrix.indices[start:end]
+        # argpartition is O(n) where n = number of non-zeros in this row.
+        top_local = np.argpartition(row_data, -k)[-k:]
+        rows.extend([row_idx] * k)
+        cols.extend(row_cols[top_local])
+        data.extend(row_data[top_local])
+    return sparse.csr_matrix((data, (rows, cols)), shape=matrix.shape)

--- a/src/recommender_systems/svd.py
+++ b/src/recommender_systems/svd.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+from collections.abc import Hashable
+
+import numpy as np
 import pandas as pd
 from sklearn.decomposition import TruncatedSVD
 
-from recommender_systems.base import _PredictedScoreRecommender
-from recommender_systems.data import build_user_item_matrix
+from recommender_systems.base import _SparseMatrixBackedRecommender
+from recommender_systems.data import build_sparse_user_item_matrix
 
 __all__ = ["SVD"]
 
 
-class SVD(_PredictedScoreRecommender):
+class SVD(_SparseMatrixBackedRecommender):
     """Recommend from a low-rank reconstruction of the user-item matrix.
+
+    Operates on the sparse user-item matrix directly. ``TruncatedSVD`` accepts
+    CSR natively, so the dense ``(n_users, n_items)`` matrix never has to be
+    materialized — the win that opens the goodbooks-full corpus to SVD.
 
     Parameters
     ----------
@@ -26,11 +33,17 @@ class SVD(_PredictedScoreRecommender):
         super().__init__()
         self.n_factors = n_factors
         self.random_state = random_state
+        self._user_factors: np.ndarray = np.empty((0, 0))
+        self._item_factors: np.ndarray = np.empty((0, 0))
 
     def fit(self, ratings: pd.DataFrame) -> SVD:
-        self._matrix = build_user_item_matrix(ratings, fill_value=0.0)
+        self._matrix, self._users, self._items = build_sparse_user_item_matrix(ratings)
         k = max(1, min(self.n_factors, min(self._matrix.shape) - 1))
         model = TruncatedSVD(n_components=k, random_state=self.random_state)
-        factors = model.fit_transform(self._matrix.to_numpy())
-        self._predicted = factors @ model.components_
+        self._user_factors = model.fit_transform(self._matrix)
+        self._item_factors = model.components_
         return self
+
+    def _user_scores(self, user_id: Hashable) -> np.ndarray:
+        u_idx = self._users.get_loc(user_id)
+        return np.asarray(self._user_factors[u_idx] @ self._item_factors)

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from scipy import sparse
 
 from recommender_systems.base import Recommender
 from recommender_systems.neighborhood import ItemKNN, UserKNN
@@ -34,3 +35,12 @@ def test_user_knn_recommends_from_nearest_neighbor():
 
 def test_unknown_user_returns_empty():
     assert UserKNN().fit(sample_ratings()).recommend(999) == []
+
+
+def test_knn_stores_sparse_matrix():
+    # Regression: the sparse-everywhere rewrite kept the recommend contract;
+    # this pins the internal representation so a future change can't silently
+    # revert to dense and reintroduce the goodbooks-10k memory blowup.
+    for cls in (ItemKNN, UserKNN):
+        model = cls().fit(sample_ratings())
+        assert sparse.issparse(model._matrix), f"{cls.__name__}._matrix is not sparse"

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from scipy import sparse
 
 from recommender_systems.base import Recommender
 from recommender_systems.svd import SVD
@@ -29,3 +30,11 @@ def test_svd_excludes_seen_and_handles_unknown_user():
     model = SVD(random_state=0).fit(sample_ratings())
     assert "a" not in model.recommend(4)
     assert model.recommend(999) == []
+
+
+def test_svd_stores_sparse_matrix():
+    # Regression: pins the sparse internal representation so a future change
+    # can't silently revert to dense and reintroduce the goodbooks-10k memory
+    # blowup the Phase 3 rewrite fixed.
+    model = SVD(random_state=0).fit(sample_ratings())
+    assert sparse.issparse(model._matrix)


### PR DESCRIPTION
## Phase 3 — sparse-aware UserKNN / ItemKNN / SVD

Closes #77. Three algorithms whose memory profile cared about the dense user-item matrix move to scipy.sparse so the goodbooks-10k corpus runs at full scale instead of the 2,500-user subsample.

### What's in the PR

- **New `_SparseMatrixBackedRecommender` base** in `base.py` — owns the CSR matrix, `pd.Index` views for users and items, and the `recommend()` contract (unknown-user fast path, seen-item mask off the row's nonzero columns, top-`n` filter). Sibling of `_MatrixBackedRecommender`; ALS / BPR / ContentBased / TwoTowerCF stay on the dense base because they aren't memory-constrained at the scales we target.

- **ItemKNN** — sparse cosine on the transposed matrix, then a private `_sparse_top_k_per_row` helper does the diagonal-and-trim step. Scoring a user is `sim @ user_row.T`.

- **UserKNN** — `sklearn.neighbors.NearestNeighbors(metric="cosine")` so the full `n_users × n_users` similarity never gets materialized. That's the one thing that was forcing the goodbooks benchmark to subsample.

- **SVD** — `TruncatedSVD` on the CSR matrix directly. It already accepted sparse; the dense pivot was the only thing keeping it from scaling.

### Local benchmark on MovieLens 100k

`tests/benchmarks/test_fit_speed.py` — also *faster* on small data because the sparse path beats the dense one even before the memory win kicks in:

| Algorithm | Phase 1.1 (dense) | Phase 3 (sparse) |
|-----------|------------------:|-----------------:|
| SVD       | 46 ms             | **29 ms**        |
| UserKNN   | 74 ms             | **33 ms**        |
| ItemKNN   | 141 ms            | **85 ms**        |

The headline is qualitative: these three can now run goodbooks-10k at full scale (53k users × 10k items, ~6M interactions). The subsample in `scripts/benchmark_goodbooks.py` remains *only* because `ContentBased` / `HybridBook` still use dense feature matrices; that's a separate phase.

### ADR

`docs/evolution/03-sparse-recommenders.md` covers context, the options that were rejected (sparse-everywhere base migration, full sparse similarity for UserKNN, approximate NN, the `sparse=True` flag pattern), and what's deliberately out of scope.

### Verification

- `ruff check` / `ruff format --check` / `mypy` clean.
- `pytest` — 137 passed, 1 skipped (the BPR kernel test skips without the compiled extension), 7 deselected (benchmarks).
- Two new regression tests (`test_knn_stores_sparse_matrix`, `test_svd_stores_sparse_matrix`) pin the sparse internal representation so a future change can't silently revert to dense.

### Backwards-incompatible

Pickles of `UserKNN` / `ItemKNN` / `SVD` written before this release don't load on the new code — the internal matrix layout shifted from dense `pd.DataFrame` to sparse CSR. Pre-1.0; documented in CHANGELOG.