### PR TITLE
docs: bring stale claims in line with what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install -e .
 ```
 
 Building from source needs a Rust toolchain — the BPR inner SGD loop lives in
-a small Rust extension (`crates/recsys-kernels/`) for a ~30× speedup over the
+a small Rust extension (`crates/recsys-kernels/`) for a ~51× speedup over the
 pure-Python loop. `brew install rust` or [rustup](https://rustup.rs/) covers
 it; `pip install` then invokes `maturin` to compile the extension. Pre-built
 wheels on PyPI (planned) skip this step for end users.
@@ -119,7 +119,7 @@ recsys evaluate  --algo svd
 | `recommender_systems.neighborhood`  | `UserKNN`, `ItemKNN` | Cosine-similarity neighborhood CF                    |
 | `recommender_systems.svd`           | `SVD`                | Truncated SVD on the user-item matrix                |
 | `recommender_systems.content`       | `ContentBased`       | Item-feature similarity (TF-IDF, tags, embeddings)   |
-| `recommender_systems.bpr`           | `BPR`                | Bayesian Personalized Ranking (numpy SGD)            |
+| `recommender_systems.bpr`           | `BPR`                | Bayesian Personalized Ranking (Rust+PyO3 kernel; Python fallback) |
 | `recommender_systems.als`           | `ALS`                | Alternating Least Squares (Hu/Koren/Volinsky 2008)   |
 | `recommender_systems.neural`        | `TwoTowerCF`         | Two-tower neural CF (PyTorch; requires `[neural]`)   |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,41 @@
 # Roadmap
 
-A polished, modern, well-tested recommender systems library — and a real book recommender
-built on top of it.
+A modern, well-tested recommender library, with a book-recommender vertical built
+on top of it.
 
 ## Shipped
 
-- **Packaging & tooling:** `src/` layout, `pyproject.toml`, Ruff lint/format, mypy, pytest,
-  CI across Python 3.10–3.12, and a published docs site.
-- **Unified API:** a `Recommender` interface (`fit` / `recommend`) so every algorithm is
-  interchangeable, a `MatrixBackedRecommender` base, and shared data utilities
-  (`build_user_item_matrix`, `split_ratings`, `holdout_per_user`, `densest_subset`).
+- **Packaging & tooling:** `src/` layout, `pyproject.toml`, Ruff lint/format, mypy,
+  pytest, pre-commit, CI across Python 3.10–3.12, and a published docs site.
+- **Unified API:** a `Recommender` interface (`fit` / `recommend`) so every algorithm
+  is interchangeable, two matrix-backed bases (dense / sparse), and shared data
+  utilities (`build_user_item_matrix`, `build_sparse_user_item_matrix`,
+  `split_ratings`, `holdout_per_user`, `densest_subset`).
 - **Algorithms:** most-popular & mean-rating baselines, user/item k-NN, SVD matrix
   factorization, implicit-feedback BPR, ALS, content-based (TF-IDF / count / binary
-  features), and a reciprocal-rank-fusion hybrid.
+  features), two-tower neural CF, and a reciprocal-rank-fusion hybrid.
 - **Evaluation:** precision@k, recall@k, MAP, NDCG, plus beyond-accuracy metrics
   (diversity, novelty, coverage, serendipity).
-- **Reproducible benchmarks** on MovieLens 100k and goodbooks-10k (committed tables +
-  charts), a `recsys` CLI, and model persistence.
-
-## In progress — the book recommender (epic #50)
-
-A book recommender that powers a real e-reader app: goodbooks-10k benchmark, tag-based
-content recommendation, two-tower neural CF, hybrid collaborative+content, explainable
-recommendations, and a worked demo.
+- **Reproducible benchmarks** on MovieLens 100k and goodbooks-10k (committed tables
+  + charts), a `recsys` CLI, and model persistence.
+- **Book recommender pipeline** (epic #50): goodbooks-10k loaders, tag-based content
+  recommendation, hybrid collaborative+content, explainable recommendations, and a
+  worked end-to-end demo.
+- **Rust+PyO3 kernel for BPR's SGD inner loop** (~51× faster fit on MovieLens 100k).
+  See `docs/evolution/02-rust-kernel-bpr.md`.
+- **Sparse-aware UserKNN / ItemKNN / SVD** so the three algorithms run goodbooks-10k
+  at full scale (closes #77). See `docs/evolution/03-sparse-recommenders.md`.
+- **Engineering ADRs** in `docs/evolution/`, including the
+  [Phase 4 refusal](docs/evolution/04-neural-stays-pytorch.md) to rewrite
+  `TwoTowerCF` and the
+  [Phase 5 serving experiment + postmortem](docs/evolution/05-go-serving-postmortem.md).
 
 ## Next
 
-- **Scale:** scipy-sparse user-item matrices so the neighborhood and matrix-factorization
-  models run on the full goodbooks-10k corpus, not just a subsample (#77).
-- **Product path (deferred):** an Open Library metadata client (#48) and a first-party
-  reading-signal model (#49) for the e-reader — commercial-safe, no scraped data.
-- **Release:** publish to PyPI.
+- **Release:** version bump, `cibuildwheel` workflow for Linux/macOS/Windows
+  pre-built wheels, trusted-publishing setup, first PyPI upload.
+- **ContentBased / HybridBook on sparse features** so the goodbooks benchmark can
+  drop the 2,500-user subsample entirely.
+- **Product path (deferred):** an Open Library metadata client (#48) and a
+  first-party reading-signal model (#49) for the e-reader — commercial-safe, no
+  scraped data.

--- a/docs/choosing_an_algorithm.md
+++ b/docs/choosing_an_algorithm.md
@@ -11,13 +11,13 @@ it shines and one where it falls over. Here's the short version.
 |-----------|---------------|--------------------------|---------------|
 | `MostPopular` | Just ratings | Cold-start baseline; a reasonable default for new users | Personalization (it gives everyone the same list) |
 | `MeanRating` | Ratings + an explicit-rating scale | When highly-rated long-tail items matter | Implicit feedback; low catalog coverage |
-| `ItemKNN` | Ratings; dense item-similarity matrix | Strong CF baseline; broad catalog coverage | Cold-start items (no item with no ratings is reachable) |
-| `UserKNN` | Ratings; dense user-similarity matrix | Communities and tight clusters | Very large user bases (`n_users x n_users` is `O(n^2)` memory) |
-| `SVD` | Ratings | Dense latent structure; smoothing | Implicit feedback where 0 is not negative |
-| `BPR` | Implicit interactions only | Implicit feedback; learning what *order* items rank in | Datasets so large the numpy SGD loop is the bottleneck |
+| `ItemKNN` | Ratings; sparse item-item cosine | Strong CF baseline; broad catalog coverage | Cold-start items (an item with no ratings is unreachable) |
+| `UserKNN` | Ratings; per-user top-k neighbors via `NearestNeighbors` | Communities and tight clusters | When you specifically want a fully precomputed user-user matrix for downstream analysis |
+| `SVD` | Ratings; `TruncatedSVD` over the sparse user-item matrix | Dense latent structure; smoothing | Implicit feedback where 0 is not negative |
+| `BPR` | Implicit interactions only | Implicit feedback; learning what *order* items rank in | When you need closed-form solves rather than SGD — reach for ALS |
 | `ALS` | Implicit interactions only | Same setting as BPR; converges in many fewer epochs | Very high `n_factors` where the per-side solves dominate |
 | `ContentBased` | Per-item features | Cold-start items, niche-content surfacing | A pure-CF win on accuracy is on the table |
-| `TwoTowerCF` | Implicit interactions; PyTorch | Showing modern deep CF works on this API | Most cases — BPR/ALS are simpler and often as strong |
+| `TwoTowerCF` | Implicit interactions; PyTorch | Embedding models with future side-information towers | Most cases — BPR/ALS are simpler and often as strong |
 | `HybridRecommender` | Two or more fitted recommenders | Blending CF with content (cold-start) or model classes | One signal is dramatically stronger — weights matter |
 
 ## When pure collaborative filtering wins

--- a/docs/evolution/02-rust-kernel-bpr.md
+++ b/docs/evolution/02-rust-kernel-bpr.md
@@ -70,7 +70,7 @@ Performance numbers (release build on Apple-Silicon):
 | BPR fit, ML-100k, 5 epochs | 4,503 ms | ~88 ms | ~51× |
 
 Hardware-dependent; the speedup ratio is what carries. The committed
-`tests/test_fit_speed.py::test_bpr_fit` benchmark now exercises the kernel
+`tests/benchmarks/test_fit_speed.py::test_bpr_fit` benchmark now exercises the kernel
 path, so the suite records a fresh number every time it runs. Full table
 in `benchmarks/profile.md`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,32 +1,46 @@
 # Recommender Systems
 
-A collection of classic and modern recommender system algorithms with a clean,
-unified API.
+A modern, fully-typed Python recommender library with a clean, unified API.
 
 ## Highlights
 
 - **One interface.** Every algorithm implements `fit(ratings)` and
   `recommend(user, n)`, so they're interchangeable.
-- **Five algorithms out of the box.** `MostPopular`, `MeanRating`, `UserKNN`,
-  `ItemKNN`, `SVD` — more on the way.
+- **Ten algorithms out of the box.** `MostPopular`, `MeanRating`, `UserKNN`,
+  `ItemKNN`, `SVD`, `BPR`, `ALS`, `ContentBased`, `TwoTowerCF`, and
+  `HybridRecommender`. See [API Reference](api.md).
+- **Compiled hot paths where they earn it.** BPR's SGD inner loop is a Rust+PyO3
+  kernel (~51× faster than the pure-Python fallback); UserKNN, ItemKNN, and SVD
+  run on `scipy.sparse` so they scale to goodbooks-10k at full size. The Python
+  fallback paths are kept so the library works without the compiled extension.
 - **Evaluation built-in.** `precision@k`, `recall@k`, `MAP`, `NDCG`, plus
   beyond-accuracy metrics (intra-list diversity, novelty, catalog coverage,
   serendipity).
-- **Datasets.** `load_movielens_100k()` downloads and caches the standard
-  benchmark; CI tests stay offline.
-- **Typed, tested, ruff-clean.** Python 3.10+; pandas / numpy / scikit-learn
-  under the hood.
+- **Datasets.** `load_movielens_100k()` and `load_goodbooks_10k()` download and
+  cache the standard benchmarks; CI tests stay offline.
+- **Typed, tested, ruff-clean.** Python 3.10+; pandas / numpy / scikit-learn /
+  scipy under the hood.
 
 ## Install
 
+The library is not on PyPI yet. From source:
+
 ```bash
-pip install recommender-systems
+git clone https://github.com/Burton-David/Recommender-Systems
+cd Recommender-Systems
+pip install -e .
 ```
 
-For the optional word-embeddings recommender:
+A Rust toolchain is required to compile the kernel — `brew install rust` or
+[rustup](https://rustup.rs/) covers it. `pip install` then invokes `maturin`
+to build the extension.
+
+For optional features:
 
 ```bash
-pip install 'recommender-systems[embeddings]'
+pip install -e '.[neural]'       # PyTorch for TwoTowerCF
+pip install -e '.[embeddings]'   # gensim for word-embedding features
+pip install -e '.[benchmarks]'   # matplotlib + tabulate for the benchmark scripts
 ```
 
 See [Quickstart](quickstart.md) for a worked example, or

--- a/serving/README.md
+++ b/serving/README.md
@@ -6,7 +6,11 @@ either and benchmarked apples-to-apples. The point of the exercise is the
 [Phase 5 postmortem](../docs/evolution/05-go-serving-postmortem.md):
 *does a Go serving layer actually pay off for this library's workload?*
 
-The answer is: not really. The postmortem walks through why.
+Short answer for this workload: yes, by a wider margin than expected — Go
+beat FastAPI + numpy on throughput, latency, and memory because the
+per-request matmul is too small for BLAS to dominate the request envelope.
+The postmortem walks through the measurement and why the original
+"Python wins on BLAS" prediction was wrong.
 
 ## What's here
 

--- a/src/recommender_systems/books.py
+++ b/src/recommender_systems/books.py
@@ -1,6 +1,6 @@
 """Book-specific helpers built on the goodbooks-10k loaders.
 
-Drop-in pipelines for the book showcase — turn the tag table from
+Drop-in pipelines for the book recommender — turn the tag table from
 ``load_goodbooks_tags`` into a content-based recommender in one call, so callers
 don't have to repeat the join + vectorize + ``ContentBased`` boilerplate.
 """


### PR DESCRIPTION
Documentation hadn't caught up with Phases 2-5. Pulled out of the audit as the highest-value cluster — seven concrete corrections, no code change.

| File | Problem | Fix |
|---|---|---|
| `serving/README.md` | Opens with "the answer is: not really" — directly contradicts the Phase 5 ADR (same file, lower down) showing Go won throughput/latency/memory | Rewrite intro to match measurement |
| `README.md:67` | Claims BPR is "~30×" faster | Bump to "~51×" to match the ADR + `benchmarks/profile.md` |
| `README.md:122` | Algorithm table called BPR "numpy SGD" | "Rust+PyO3 kernel; Python fallback" |
| `docs/index.md` | "Five algorithms out of the box" + `pip install recommender-systems` | List all ten algorithms; source-install recipe with the Rust toolchain prereq |
| `docs/choosing_an_algorithm.md` | BPR "when it isn't" still mentioned the numpy SGD bottleneck (gone since Phase 2); k-NN/SVD rows said "dense" | Reframed BPR to ALS-as-alternative; updated data-source columns to reflect Phase 3's sparse rewrite |
| `ROADMAP.md` | Pre-Phase-2: book recommender listed as in-progress (shipped); #77 sparse work listed as next (shipped); Rust kernel and serving experiment entirely absent | Rewrote Shipped to reflect reality; Next is release + ContentBased-on-sparse |
| `src/recommender_systems/books.py` | Module docstring used "showcase" — the one remaining instance, surfaced into `api.md` via mkdocstrings | "recommender" |
| `docs/evolution/02-rust-kernel-bpr.md:73` | Pointed at `tests/test_fit_speed.py` | `tests/benchmarks/test_fit_speed.py` |

### Verification
- `ruff check` / `ruff format --check` / `mypy` clean
- `pytest` — 137 passed, 1 skipped (kernel without build), 7 deselected
- `mkdocs build --strict` — 0 warnings