### PR TITLE
chore: bump to 0.5.0; flesh out classifiers and project urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [0.5.0]
+
 ### Documented
 
 - `docs/evolution/05-go-serving-postmortem.md` — postmortem of the Go

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,19 @@ keywords = [
     "machine-learning",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
 ]
 dependencies = [
     "numpy>=1.23",
@@ -31,7 +36,7 @@ dependencies = [
     "scikit-learn>=1.2",
     "scipy>=1.9",
 ]
-version = "0.1.0"
+version = "0.5.0"
 
 [project.optional-dependencies]
 benchmarks = [
@@ -56,6 +61,9 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/Burton-David/Recommender-Systems"
 Repository = "https://github.com/Burton-David/Recommender-Systems"
+Documentation = "https://burton-david.github.io/Recommender-Systems/"
+Issues = "https://github.com/Burton-David/Recommender-Systems/issues"
+Changelog = "https://github.com/Burton-David/Recommender-Systems/blob/main/CHANGELOG.md"
 
 [project.scripts]
 recsys = "recommender_systems.cli:main"


### PR DESCRIPTION
Three audit-pulled fixes, single cohesive PR, no code change beyond `pyproject.toml` + `CHANGELOG.md`.

| | |
|---|---|
| **Version** | `0.1.0` → `0.5.0` (five phases have shipped; CHANGELOG `[Unreleased]` cut into `[0.5.0]`). `__version__` reads from installed metadata so this is the single source of truth. |
| **Classifiers** | Added `Programming Language :: Rust` (the kernel is part of the build), `Typing :: Typed` (PEP 561 marker has shipped since v0.1.0 but wasn't advertised), `Python :: 3 :: Only`, the CPython implementation classifier, and the OS independent classifier. Development status moved `3 - Alpha` → `4 - Beta`. |
| **Project URLs** | Added `Documentation` (docs site), `Issues` (GitHub issues), `Changelog` (CHANGELOG.md on main) — the three PyPI sidebar entries that get scanned every time someone lands on a package page. |

### Verification

- `ruff check` / `ruff format --check` / `mypy` clean
- `pytest` — 137 passed, 1 skipped, 7 deselected
- Local `__version__` still reports `0.1.0` because the editable install on this machine wasn't refreshed; once the wheel rebuilds (CI) it will read `0.5.0`